### PR TITLE
Use `java.time.Duration` for time estiamtes instead of `float`

### DIFF
--- a/api/src/main/java/io/kroxylicious/testing/kafka/api/KafkaClusterProvisioningStrategy.java
+++ b/api/src/main/java/io/kroxylicious/testing/kafka/api/KafkaClusterProvisioningStrategy.java
@@ -6,6 +6,7 @@
 package io.kroxylicious.testing.kafka.api;
 
 import java.lang.annotation.Annotation;
+import java.time.Duration;
 import java.util.List;
 
 /**
@@ -32,7 +33,7 @@ public interface KafkaClusterProvisioningStrategy {
      * @param declarationType The specific subtype of {@link KafkaCluster} to be created.
      * @return The estimated provisioning time (including the time taken for {@link KafkaCluster#start()}.
      */
-    float estimatedProvisioningTimeMs(List<Annotation> constraints,
+    Duration estimatedProvisioningTimeMs(List<Annotation> constraints,
                                       Class<? extends KafkaCluster> declarationType);
 
     /**

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMProvisioningStrategy.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMProvisioningStrategy.java
@@ -6,6 +6,7 @@
 package io.kroxylicious.testing.kafka.invm;
 
 import java.lang.annotation.Annotation;
+import java.time.Duration;
 import java.util.List;
 import java.util.Set;
 
@@ -47,7 +48,7 @@ public class InVMProvisioningStrategy implements KafkaClusterProvisioningStrateg
     }
 
     @Override
-    public float estimatedProvisioningTimeMs(List<Annotation> constraints, Class<? extends KafkaCluster> declarationType) {
-        return 500;
+    public Duration estimatedProvisioningTimeMs(List<Annotation> constraints, Class<? extends KafkaCluster> declarationType) {
+        return Duration.ofMillis(500);
     }
 }

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersProvisioningStrategy.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersProvisioningStrategy.java
@@ -6,6 +6,7 @@
 package io.kroxylicious.testing.kafka.testcontainers;
 
 import java.lang.annotation.Annotation;
+import java.time.Duration;
 import java.util.List;
 import java.util.Set;
 
@@ -47,7 +48,7 @@ public class TestcontainersProvisioningStrategy implements KafkaClusterProvision
     }
 
     @Override
-    public float estimatedProvisioningTimeMs(List<Annotation> constraints, Class<? extends KafkaCluster> declarationType) {
-        return 1000;
+    public Duration estimatedProvisioningTimeMs(List<Annotation> constraints, Class<? extends KafkaCluster> declarationType) {
+        return Duration.ofSeconds(1);
     }
 }


### PR DESCRIPTION
Signed-off-by: Sam Barker <sbarker@redhat.com>