### PR TITLE
Factor User into a top-level repeatable annotation

### DIFF
--- a/api/src/main/java/io/kroxylicious/testing/kafka/api/KafkaClusterProvisioningStrategy.java
+++ b/api/src/main/java/io/kroxylicious/testing/kafka/api/KafkaClusterProvisioningStrategy.java
@@ -34,7 +34,7 @@ public interface KafkaClusterProvisioningStrategy {
      * @return The estimated provisioning time (including the time taken for {@link KafkaCluster#start()}.
      */
     Duration estimatedProvisioningTimeMs(List<Annotation> constraints,
-                                      Class<? extends KafkaCluster> declarationType);
+                                         Class<? extends KafkaCluster> declarationType);
 
     /**
      * Create a {@link KafkaCluster} instance with the given configuration.

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
@@ -86,6 +86,8 @@ public class KafkaClusterConfig {
             KRaftCluster.class,
             Tls.class,
             SaslPlainAuth.class,
+            User.class,
+            User.List.class,
             ZooKeeperCluster.class);
 
     public static boolean supportsConstraint(Class<? extends Annotation> annotation) {
@@ -116,10 +118,14 @@ public class KafkaClusterConfig {
             if (annotation instanceof SaslPlainAuth) {
                 builder.saslMechanism("PLAIN");
                 sasl = true;
-                builder.users(Arrays.stream(((SaslPlainAuth) annotation).value())
-                        .collect(Collectors.toMap(
-                                SaslPlainAuth.UserPassword::user,
-                                SaslPlainAuth.UserPassword::password)));
+            }
+            if (annotation instanceof User) {
+                builder.user(((User) annotation).user(), ((User) annotation).password());
+            }
+            if (annotation instanceof User.List) {
+                Arrays.stream(((User.List) annotation).value()).forEach(user -> {
+                    builder.user(user.user(), user.password());
+                });
             }
             if (annotation instanceof ClusterId) {
                 builder.kafkaKraftClusterId(((ClusterId) annotation).value());

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/User.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/User.java
@@ -6,21 +6,32 @@
 package io.kroxylicious.testing.kafka.common;
 
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import io.kroxylicious.testing.kafka.api.KafkaClusterConstraint;
-import io.kroxylicious.testing.kafka.api.KafkaClusterProvisioningStrategy;
 
-/**
- * Annotation constraining a {@link KafkaClusterProvisioningStrategy} to use
- * provide a cluster that supports SASL-PLAIN. {@link User @User} annotations can be used to
- * configure the cluster with users.
- */
 @Target({ ElementType.PARAMETER, ElementType.FIELD })
 @Retention(RetentionPolicy.RUNTIME)
+@Repeatable(User.List.class)
 @KafkaClusterConstraint
-public @interface SaslPlainAuth {
+public @interface User {
+    /**
+     * @return A user name.
+     */
+    String user();
 
+    /**
+     * @return A password.
+     */
+    String password();
+
+    @Target({ ElementType.PARAMETER, ElementType.FIELD })
+    @Retention(RetentionPolicy.RUNTIME)
+    @KafkaClusterConstraint
+    @interface List {
+        User[] value();
+    }
 }


### PR DESCRIPTION
The idea being that @User could also be used to support a @SaslScramSha annotation, and maybe @SaslOauthBearer too.