### PR TITLE
Remove use of flag files to determine zookeeper/kafka readiness / fix SSL 

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -76,13 +76,11 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>${assertj-core.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -92,12 +90,10 @@
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <version>18.0.0</version>
         </dependency>
         <dependency>
             <groupId>org.rnorth.duct-tape</groupId>
             <artifactId>duct-tape</artifactId>
-            <version>1.0.8</version>
         </dependency>
         <dependency>
             <!-- Note we use System.Logger facade in src/main/java. log4j2 only for the tests -->
@@ -115,6 +111,11 @@
             <!-- Route Kafka an ZooKeepers use of slf4j to log4j2 -->
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
@@ -25,6 +25,8 @@ import java.util.stream.Stream;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.junit.jupiter.api.TestInfo;
 
@@ -228,12 +230,13 @@ public class KafkaClusterConfig {
                 catch (GeneralSecurityException | IOException e) {
                     throw new RuntimeException(e);
                 }
-                server.put("ssl.client.auth", "required");
-                server.put("ssl.truststore.location", keytoolCertificateGenerator.getCertLocation());
-                server.put("ssl.truststore.password", keytoolCertificateGenerator.getPassword());
-                server.put("ssl.keystore.location", keytoolCertificateGenerator.getCertLocation());
-                server.put("ssl.keystore.password", keytoolCertificateGenerator.getPassword());
-                server.put("ssl.key.password", keytoolCertificateGenerator.getPassword());
+                server.put(BrokerSecurityConfigs.SSL_CLIENT_AUTH_CONFIG, "required");
+
+                server.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, keytoolCertificateGenerator.getCertLocation());
+                server.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, keytoolCertificateGenerator.getPassword());
+                server.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, keytoolCertificateGenerator.getCertLocation());
+                server.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, keytoolCertificateGenerator.getPassword());
+                server.put(SslConfigs.SSL_KEY_PASSWORD_CONFIG, keytoolCertificateGenerator.getPassword());
             }
 
             putConfig(server, "offsets.topic.replication.factor", Integer.toString(1));
@@ -281,12 +284,12 @@ public class KafkaClusterConfig {
             kafkaConfig.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, securityProtocol);
 
             if (securityProtocol.contains("SSL")) {
-                kafkaConfig.put("ssl.truststore.location", keytoolCertificateGenerator.getCertLocation());
-                kafkaConfig.put("ssl.truststore.password", keytoolCertificateGenerator.getPassword());
+                kafkaConfig.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, keytoolCertificateGenerator.getCertLocation());
+                kafkaConfig.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, keytoolCertificateGenerator.getPassword());
                 if (securityProtocol.equals(SecurityProtocol.SSL.name())) {
-                    kafkaConfig.put("ssl.keystore.location", keytoolCertificateGenerator.getCertLocation());
-                    kafkaConfig.put("ssl.keystore.password", keytoolCertificateGenerator.getPassword());
-                    kafkaConfig.put("ssl.key.password", keytoolCertificateGenerator.getPassword());
+                    kafkaConfig.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, keytoolCertificateGenerator.getCertLocation());
+                    kafkaConfig.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, keytoolCertificateGenerator.getPassword());
+                    kafkaConfig.put(SslConfigs.SSL_KEY_PASSWORD_CONFIG, keytoolCertificateGenerator.getPassword());
                 }
             }
         }

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
@@ -27,7 +27,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.TestInfo;
-import org.rnorth.ducttape.unreliables.Unreliables;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.output.OutputFrame;
@@ -58,8 +57,6 @@ public class TestcontainersKafkaCluster implements Startable, KafkaCluster {
     // FIXME: uses container image built from https://github.com/k-wall/zookeeper-native, move the repo to a permanent location.
     private static final DockerImageName DEFAULT_ZOOKEEPER_IMAGE = DockerImageName.parse("quay.io/k_wall/zookeeper-native:1.0.0-SNAPSHOT");
     private static final int READY_TIMEOUT_SECONDS = 120;
-    private static final String KAFKA_CLUSTER_READY_FLAG = "/tmp/kafka_cluster_ready";
-    private static final String ZOOKEEPER_READY_FLAG = "/tmp/kafka_zookeeper_ready";
     private final DockerImageName kafkaImage;
     private final DockerImageName zookeeperImage;
     private final KafkaClusterConfig clusterConfig;
@@ -96,7 +93,6 @@ public class TestcontainersKafkaCluster implements Startable, KafkaCluster {
             this.zookeeper = new ZookeeperContainer(this.zookeeperImage)
                     .withName(name)
                     .withNetwork(network)
-                    .withEnv("SERVER_ZOOKEEPER_READY_FLAG_FILE", ZOOKEEPER_READY_FLAG)
                     // .withEnv("QUARKUS_LOG_LEVEL", "DEBUG") // Enables org.apache.zookeeper logging too
                     .withNetworkAliases("zookeeper");
         }
@@ -130,8 +126,6 @@ public class TestcontainersKafkaCluster implements Startable, KafkaCluster {
                     // .withEnv("QUARKUS_LOG_LEVEL", "DEBUG") // Enables org.apache.kafka logging too
                     .withEnv("SERVER_PROPERTIES_FILE", "/cnf/server.properties")
                     .withEnv("SERVER_CLUSTER_ID", holder.getKafkaKraftClusterId())
-                    .withEnv("SERVER_CLUSTER_READY_FLAG_FILE", KAFKA_CLUSTER_READY_FLAG)
-                    .withEnv("SERVER_CLUSTER_READY_NUM_BROKERS", clusterConfig.getBrokersNum().toString())
                     .withCopyToContainer(Transferable.of(propertiesToBytes(holder.getProperties()), 0644), "/cnf/server.properties")
                     .withStartupTimeout(Duration.ofMinutes(2));
 
@@ -173,7 +167,6 @@ public class TestcontainersKafkaCluster implements Startable, KafkaCluster {
         try {
             if (zookeeper != null) {
                 zookeeper.start();
-                awaitContainerReadyFlagFile(zookeeper, ZOOKEEPER_READY_FLAG);
             }
             Startables.deepStart(brokers.stream()).get(READY_TIMEOUT_SECONDS, TimeUnit.SECONDS);
         }
@@ -184,23 +177,11 @@ public class TestcontainersKafkaCluster implements Startable, KafkaCluster {
             stop();
             throw new RuntimeException("startup failed or timed out", e);
         }
-
-        awaitContainerReadyFlagFile(this.brokers.iterator().next(), KAFKA_CLUSTER_READY_FLAG);
     }
 
     @Override
     public void close() {
         this.stop();
-    }
-
-    private void awaitContainerReadyFlagFile(GenericContainer<?> container, String kafkaClusterReadyFlag) {
-        Unreliables.retryUntilTrue(READY_TIMEOUT_SECONDS, TimeUnit.SECONDS, () -> {
-            container.execInContainer(
-                    "sh", "-c",
-                    String.format("while [ ! -f %s ]; do sleep .1; done", kafkaClusterReadyFlag));
-            LOGGER.log(Level.INFO, "Container {0} ready", container.getDockerImageName());
-            return true;
-        });
     }
 
     @Override

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/KafkaClusterTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/KafkaClusterTest.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package io.kroxylicious.testing.kafka.common;
+package io.kroxylicious.testing.kafka;
 
 import java.io.IOException;
 import java.nio.file.Path;
@@ -30,10 +30,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import io.kroxylicious.testing.kafka.common.KafkaClusterConfig;
+import io.kroxylicious.testing.kafka.common.KafkaClusterFactory;
+import io.kroxylicious.testing.kafka.common.KeytoolCertificateGenerator;
 import io.kroxylicious.testing.kafka.testcontainers.TestcontainersKafkaCluster;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
 /**
  * Test case that simply exercises the ability to control the kafka cluster from the test.
@@ -42,6 +46,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 public class KafkaClusterTest {
 
     private static final System.Logger LOGGER = System.getLogger(KafkaClusterTest.class.getName());
+    private static final Duration CLUSTER_FORMATION_TIMEOUT = Duration.ofSeconds(10);
     private TestInfo testInfo;
     private KeytoolCertificateGenerator keytoolCertificateGenerator;
 
@@ -183,7 +188,7 @@ public class KafkaClusterTest {
         var message = "Hello, world!";
 
         try (var admin = KafkaAdminClient.create(cluster.getKafkaClientConfiguration())) {
-            assertEquals(expected, getActualNumberOfBrokers(admin));
+            await().atMost(CLUSTER_FORMATION_TIMEOUT).untilAsserted(() -> assertEquals(expected, getActualNumberOfBrokers(admin)));
             var rf = (short) Math.min(1, Math.max(expected, 3));
             createTopic(admin, topic, rf);
         }

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/ParameterExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/ParameterExtensionTest.java
@@ -40,12 +40,12 @@ import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 @ExtendWith(KafkaClusterExtension.class)
 public class ParameterExtensionTest extends AbstractExtensionTest {
 
-    private static final Duration NODE_TIMEOUT = Duration.ofSeconds(5);
+    private static final Duration CLUSTER_FORMATION_TIMEOUT = Duration.ofSeconds(10);
 
     @Test
     public void clusterParameter(@BrokerCluster(numBrokers = 2) KafkaCluster cluster)
             throws ExecutionException, InterruptedException {
-        await().atMost(NODE_TIMEOUT).untilAsserted(() -> assertEquals(2, describeCluster(cluster.getKafkaClientConfiguration()).nodes().get().size()));
+        await().atMost(CLUSTER_FORMATION_TIMEOUT).untilAsserted(() -> assertEquals(2, describeCluster(cluster.getKafkaClientConfiguration()).nodes().get().size()));
         var dc = describeCluster(cluster.getKafkaClientConfiguration());
         assertEquals(cluster.getClusterId(), dc.clusterId().get());
         assertInstanceOf(InVMKafkaCluster.class, cluster);
@@ -67,7 +67,7 @@ public class ParameterExtensionTest extends AbstractExtensionTest {
                                          Admin admin)
             throws ExecutionException, InterruptedException {
         var dc = assertSameCluster(cluster, admin);
-        await().atMost(NODE_TIMEOUT).untilAsserted(() -> assertEquals(2, describeCluster(admin).nodes().get().size()));
+        await().atMost(CLUSTER_FORMATION_TIMEOUT).untilAsserted(() -> assertEquals(2, describeCluster(admin).nodes().get().size()));
         assertInstanceOf(InVMKafkaCluster.class, cluster);
     }
 
@@ -82,7 +82,7 @@ public class ParameterExtensionTest extends AbstractExtensionTest {
         assertEquals(1, dc1.nodes().get().size());
         var dc2 = describeCluster(cluster2.getKafkaClientConfiguration());
         assertEquals(cluster2.getClusterId(), dc2.clusterId().get());
-        await().atMost(NODE_TIMEOUT).untilAsserted(() -> assertEquals(2, describeCluster(cluster2.getKafkaClientConfiguration()).nodes().get().size()));
+        await().atMost(CLUSTER_FORMATION_TIMEOUT).untilAsserted(() -> assertEquals(2, describeCluster(cluster2.getKafkaClientConfiguration()).nodes().get().size()));
     }
 
     // @Name is not required here because there's no ambiguity
@@ -92,7 +92,7 @@ public class ParameterExtensionTest extends AbstractExtensionTest {
                                            @BrokerCluster(numBrokers = 2) KafkaCluster cluster2)
             throws ExecutionException, InterruptedException {
         assertEquals(1, describeCluster(cluster1.getKafkaClientConfiguration()).nodes().get().size());
-        await().atMost(NODE_TIMEOUT).untilAsserted(() -> assertEquals(2, describeCluster(cluster2.getKafkaClientConfiguration()).nodes().get().size()));
+        await().atMost(CLUSTER_FORMATION_TIMEOUT).untilAsserted(() -> assertEquals(2, describeCluster(cluster2.getKafkaClientConfiguration()).nodes().get().size()));
     }
 
     @Test
@@ -106,7 +106,7 @@ public class ParameterExtensionTest extends AbstractExtensionTest {
         assertEquals(1, describeCluster(clusterA.getKafkaClientConfiguration()).nodes().get().size());
         assertEquals(1, describeCluster(adminA).nodes().get().size());
         assertSameCluster(clusterB, adminB);
-        await().atMost(NODE_TIMEOUT).untilAsserted(() -> assertEquals(2, describeCluster(clusterB.getKafkaClientConfiguration()).nodes().get().size()));
+        await().atMost(CLUSTER_FORMATION_TIMEOUT).untilAsserted(() -> assertEquals(2, describeCluster(clusterB.getKafkaClientConfiguration()).nodes().get().size()));
         assertEquals(2, describeCluster(adminB).nodes().get().size());
     }
 

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/ParameterExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/ParameterExtensionTest.java
@@ -8,7 +8,6 @@ package io.kroxylicious.testing.kafka.junit5ext;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 import org.apache.kafka.clients.admin.Admin;
@@ -46,7 +45,7 @@ public class ParameterExtensionTest extends AbstractExtensionTest {
     @Test
     public void clusterParameter(@BrokerCluster(numBrokers = 2) KafkaCluster cluster)
             throws ExecutionException, InterruptedException {
-        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertEquals(2, describeCluster(cluster.getKafkaClientConfiguration()).nodes().get().size()));
+        await().atMost(NODE_TIMEOUT).untilAsserted(() -> assertEquals(2, describeCluster(cluster.getKafkaClientConfiguration()).nodes().get().size()));
         var dc = describeCluster(cluster.getKafkaClientConfiguration());
         assertEquals(cluster.getClusterId(), dc.clusterId().get());
         assertInstanceOf(InVMKafkaCluster.class, cluster);

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/ParameterExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/ParameterExtensionTest.java
@@ -5,8 +5,10 @@
  */
 package io.kroxylicious.testing.kafka.junit5ext;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 import org.apache.kafka.clients.admin.Admin;
@@ -34,17 +36,20 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
 @ExtendWith(KafkaClusterExtension.class)
 public class ParameterExtensionTest extends AbstractExtensionTest {
 
+    private static final Duration NODE_TIMEOUT = Duration.ofSeconds(5);
+
     @Test
     public void clusterParameter(@BrokerCluster(numBrokers = 2) KafkaCluster cluster)
             throws ExecutionException, InterruptedException {
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted(() -> assertEquals(2, describeCluster(cluster.getKafkaClientConfiguration()).nodes().get().size()));
         var dc = describeCluster(cluster.getKafkaClientConfiguration());
-        assertEquals(2, dc.nodes().get().size());
         assertEquals(cluster.getClusterId(), dc.clusterId().get());
-        var cbc = assertInstanceOf(InVMKafkaCluster.class, cluster);
+        assertInstanceOf(InVMKafkaCluster.class, cluster);
     }
 
     @Test
@@ -63,8 +68,8 @@ public class ParameterExtensionTest extends AbstractExtensionTest {
                                          Admin admin)
             throws ExecutionException, InterruptedException {
         var dc = assertSameCluster(cluster, admin);
-        assertEquals(2, dc.nodes().get().size());
-        var cbc = assertInstanceOf(InVMKafkaCluster.class, cluster);
+        await().atMost(NODE_TIMEOUT).untilAsserted(() -> assertEquals(2, describeCluster(admin).nodes().get().size()));
+        assertInstanceOf(InVMKafkaCluster.class, cluster);
     }
 
     @Test
@@ -74,11 +79,11 @@ public class ParameterExtensionTest extends AbstractExtensionTest {
             throws ExecutionException, InterruptedException {
         assertNotEquals(cluster1.getClusterId(), cluster2.getClusterId());
         var dc1 = describeCluster(cluster1.getKafkaClientConfiguration());
-        assertEquals(1, dc1.nodes().get().size());
         assertEquals(cluster1.getClusterId(), dc1.clusterId().get());
+        assertEquals(1, dc1.nodes().get().size());
         var dc2 = describeCluster(cluster2.getKafkaClientConfiguration());
-        assertEquals(2, dc2.nodes().get().size());
         assertEquals(cluster2.getClusterId(), dc2.clusterId().get());
+        await().atMost(NODE_TIMEOUT).untilAsserted(() -> assertEquals(2, describeCluster(cluster2.getKafkaClientConfiguration()).nodes().get().size()));
     }
 
     // @Name is not required here because there's no ambiguity
@@ -87,10 +92,8 @@ public class ParameterExtensionTest extends AbstractExtensionTest {
                                            @BrokerCluster(numBrokers = 1) KafkaCluster cluster1,
                                            @BrokerCluster(numBrokers = 2) KafkaCluster cluster2)
             throws ExecutionException, InterruptedException {
-        var dc1 = describeCluster(cluster1.getKafkaClientConfiguration());
-        assertEquals(1, dc1.nodes().get().size());
-        var dc2 = describeCluster(cluster2.getKafkaClientConfiguration());
-        assertEquals(2, dc2.nodes().get().size());
+        assertEquals(1, describeCluster(cluster1.getKafkaClientConfiguration()).nodes().get().size());
+        await().atMost(NODE_TIMEOUT).untilAsserted(() -> assertEquals(2, describeCluster(cluster2.getKafkaClientConfiguration()).nodes().get().size()));
     }
 
     @Test
@@ -100,13 +103,11 @@ public class ParameterExtensionTest extends AbstractExtensionTest {
                                                    @Name("B") Admin adminB,
                                                    @Name("A") Admin adminA)
             throws ExecutionException, InterruptedException {
-        var dc1 = describeCluster(clusterA.getKafkaClientConfiguration());
         assertSameCluster(clusterA, adminA);
-        assertEquals(1, dc1.nodes().get().size());
+        assertEquals(1, describeCluster(clusterA.getKafkaClientConfiguration()).nodes().get().size());
         assertEquals(1, describeCluster(adminA).nodes().get().size());
-        var dc2 = describeCluster(clusterB.getKafkaClientConfiguration());
         assertSameCluster(clusterB, adminB);
-        assertEquals(2, dc2.nodes().get().size());
+        await().atMost(NODE_TIMEOUT).untilAsserted(() -> assertEquals(2, describeCluster(clusterB.getKafkaClientConfiguration()).nodes().get().size()));
         assertEquals(2, describeCluster(adminB).nodes().get().size());
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,9 @@
         <assertj-core.version>3.22.0</assertj-core.version>
         <zookeeper.version>3.6.3</zookeeper.version>
         <log4j.version>2.19.0</log4j.version>
+        <awaitility.version>4.2.0</awaitility.version>
+        <annotations.version>18.0.0</annotations.version>
+        <duct-tape.version>1.0.8</duct-tape.version>
         <!-- Avoids issues with ryuk when running with podman https://github.com/containers/podman/issues/7927#issuecomment-731525556 -->
         <testcontainers.ryuk.disabled>true</testcontainers.ryuk.disabled>
     </properties>
@@ -83,36 +86,64 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-        <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka-clients</artifactId>
-            <version>${kafka.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka_2.13</artifactId>
-            <version>${kafka.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka-server-common</artifactId>
-            <version>${kafka.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.zookeeper</groupId>
-            <artifactId>zookeeper</artifactId>
-            <version>${zookeeper.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka-clients</artifactId>
+                <version>${kafka.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka_2.13</artifactId>
+                <version>${kafka.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka-server-common</artifactId>
+                <version>${kafka.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.zookeeper</groupId>
+                <artifactId>zookeeper</artifactId>
+                <version>${zookeeper.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-log4j12</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.awaitility</groupId>
+                <artifactId>awaitility</artifactId>
+                <version>${awaitility.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${assertj-core.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok</artifactId>
+                <version>${lombok.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jetbrains</groupId>
+                <artifactId>annotations</artifactId>
+                <version>${annotations.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.rnorth.duct-tape</groupId>
+                <artifactId>duct-tape</artifactId>
+                <version>${duct-tape.version}</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
We decided we didn't want to overload the broker/zookeeper containers with the knowledge.

Also - fixed the issue that prevents the TLS tests working when running within container.