### PR TITLE
Refactor some tests to use assertAll

### DIFF
--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/InstanceFieldExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/InstanceFieldExtensionTest.java
@@ -15,6 +15,7 @@ import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.common.BrokerCluster;
 import io.kroxylicious.testing.kafka.invm.InVMKafkaCluster;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
@@ -28,9 +29,11 @@ public class InstanceFieldExtensionTest extends AbstractExtensionTest {
     public void clusterInstanceField()
             throws ExecutionException, InterruptedException {
         var dc = describeCluster(instanceCluster.getKafkaClientConfiguration());
-        assertEquals(1, dc.nodes().get().size());
-        assertEquals(instanceCluster.getClusterId(), dc.clusterId().get());
-        var cbc = assertInstanceOf(InVMKafkaCluster.class, instanceCluster);
+        assertAll(
+                () -> assertEquals(1, dc.nodes().get().size()),
+                () -> assertEquals(instanceCluster.getClusterId(), dc.clusterId().get()),
+                () -> assertInstanceOf(InVMKafkaCluster.class, instanceCluster)
+        );
     }
 
     @Test

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/ParameterExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/ParameterExtensionTest.java
@@ -46,7 +46,7 @@ public class ParameterExtensionTest extends AbstractExtensionTest {
     @Test
     public void clusterParameter(@BrokerCluster(numBrokers = 2) KafkaCluster cluster)
             throws ExecutionException, InterruptedException {
-        await().atMost(CLUSTER_FORMATION_TIMEOUT).untilAsserted(() -> assertEquals(2, describeCluster(cluster.getKafkaClientConfiguration()).nodes().get().size()))
+        await().atMost(CLUSTER_FORMATION_TIMEOUT).untilAsserted(() -> assertEquals(2, describeCluster(cluster.getKafkaClientConfiguration()).nodes().get().size()));
         var dc = describeCluster(cluster.getKafkaClientConfiguration());
         assertAll(
                 () -> assertEquals(cluster.getClusterId(), dc.clusterId().get()),

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/StaticFieldExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/StaticFieldExtensionTest.java
@@ -22,6 +22,7 @@ import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.common.BrokerCluster;
 import io.kroxylicious.testing.kafka.invm.InVMKafkaCluster;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
@@ -42,9 +43,11 @@ public class StaticFieldExtensionTest extends AbstractExtensionTest {
     public void testKafkaClusterStaticField()
             throws ExecutionException, InterruptedException {
         var dc = describeCluster(staticCluster.getKafkaClientConfiguration());
-        assertEquals(1, dc.nodes().get().size());
-        assertEquals(staticCluster.getClusterId(), dc.clusterId().get());
-        var cbc = assertInstanceOf(InVMKafkaCluster.class, staticCluster);
+        assertAll(
+                () -> assertEquals(1, dc.nodes().get().size()),
+                () -> assertEquals(staticCluster.getClusterId(), dc.clusterId().get()),
+                () -> assertInstanceOf(InVMKafkaCluster.class, staticCluster)
+        );
     }
 
     @Test

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/StaticFieldSubclassExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/StaticFieldSubclassExtensionTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import io.kroxylicious.testing.kafka.common.BrokerCluster;
 import io.kroxylicious.testing.kafka.testcontainers.TestcontainersKafkaCluster;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
@@ -36,9 +37,11 @@ public class StaticFieldSubclassExtensionTest extends AbstractExtensionTest {
     public void testKafkaClusterStaticField()
             throws ExecutionException, InterruptedException {
         var dc = describeCluster(staticCluster.getKafkaClientConfiguration());
-        assertEquals(1, dc.nodes().get().size());
-        assertEquals(staticCluster.getClusterId(), dc.clusterId().get());
-        var cbc = assertInstanceOf(TestcontainersKafkaCluster.class, staticCluster);
+        assertAll(
+                () -> assertEquals(1, dc.nodes().get().size()),
+                () -> assertEquals(staticCluster.getClusterId(), dc.clusterId().get()),
+                () -> assertInstanceOf(TestcontainersKafkaCluster.class, staticCluster)
+        );
     }
 
     @Test


### PR DESCRIPTION
As I mention in a discussion in another thread, I suggest to avoid many assertions in one test or at least do it all together to avoid not testing something useful because the previous assertion fails.

To improve that, I decide to add `assertAll` to those tests that needed it and split negative tests to clarify the goal of each test and simplify them.

WDYT? @tombentley @SamBarker @k-wall 