### PR TITLE
Use admin client to confirm cluster is correctly started

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -116,7 +116,6 @@
         <dependency>
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
@@ -172,7 +172,7 @@ public class KafkaClusterConfig {
             var anonEndpoint = kafkaEndpoints.getAnonEndpoint(brokerNum);
 
             // - EXTERNAL: used for communications to/from consumers/producers optionally with authentication
-            // - ANON: used for communications to/from consumers/producers without authentication primarily for the extension to validte the cluster
+            // - ANON: used for communications to/from consumers/producers without authentication primarily for the extension to validate the cluster
             // - INTERNAL: used for inter-broker communications (always no auth)
             // - CONTROLLER: used for inter-broker controller communications (kraft - always no auth)
 

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
@@ -280,6 +280,7 @@ public class KafkaClusterConfig {
             throw new RuntimeException("Cannot override broker config '" + key + "=" + value + "' with new value " + orig);
         }
     }
+
     @NotNull
     public String buildClientBootstrapServers(KafkaEndpoints endPointConfig) {
         return buildBootstrapServers(getBrokersNum(), endPointConfig::getClientEndpoint);

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
@@ -296,13 +296,6 @@ public class KafkaClusterConfig {
         return buildBootstrapServers(getBrokersNum(), kafkaEndpoints::getInterBrokerEndpoint);
     }
 
-    public String buildBootstrapServers(Integer numBrokers, IntFunction<KafkaEndpoints.EndpointPair> brokerEndpoint) {
-        return IntStream.range(0, numBrokers)
-                .mapToObj(brokerEndpoint)
-                .map(KafkaEndpoints.EndpointPair::connectAddress)
-                .collect(Collectors.joining(","));
-    }
-
     public Map<String, Object> getConnectConfigForCluster(String bootstrapServers) {
         if (saslMechanism != null) {
             Map<String, String> users = getUsers();
@@ -396,6 +389,13 @@ public class KafkaClusterConfig {
 
     public String clusterId() {
         return isKraftMode() ? kafkaKraftClusterId : null;
+    }
+
+    private String buildBootstrapServers(Integer numBrokers, IntFunction<KafkaEndpoints.EndpointPair> brokerEndpoint) {
+        return IntStream.range(0, numBrokers)
+                .mapToObj(brokerEndpoint)
+                .map(KafkaEndpoints.EndpointPair::connectAddress)
+                .collect(Collectors.joining(","));
     }
 
     @Builder

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
@@ -5,7 +5,6 @@
  */
 package io.kroxylicious.testing.kafka.common;
 
-import io.kroxylicious.testing.kafka.common.KafkaClusterConfig.KafkaEndpoints.Endpoint;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Singular;
@@ -39,6 +38,8 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+
+import io.kroxylicious.testing.kafka.common.KafkaClusterConfig.KafkaEndpoints.Endpoint;
 
 @Builder(toBuilder = true)
 @Getter

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
@@ -5,6 +5,20 @@
  */
 package io.kroxylicious.testing.kafka.common;
 
+import io.kroxylicious.testing.kafka.common.KafkaClusterConfig.KafkaEndpoints.Endpoint;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Singular;
+import lombok.ToString;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.config.SaslConfigs;
+import org.apache.kafka.common.config.SslConfigs;
+import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.TestInfo;
+
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.nio.file.Files;
@@ -25,21 +39,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-
-import org.apache.kafka.clients.CommonClientConfigs;
-import org.apache.kafka.common.Uuid;
-import org.apache.kafka.common.config.SaslConfigs;
-import org.apache.kafka.common.config.SslConfigs;
-import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
-import org.apache.kafka.common.security.auth.SecurityProtocol;
-import org.jetbrains.annotations.NotNull;
-import org.junit.jupiter.api.TestInfo;
-
-import io.kroxylicious.testing.kafka.common.KafkaClusterConfig.KafkaEndpoints.Endpoint;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.Singular;
-import lombok.ToString;
 
 @Builder(toBuilder = true)
 @Getter
@@ -249,7 +248,7 @@ public class KafkaClusterConfig {
                     throw new RuntimeException("brokerKeytoolCertificateGenerator needs to be initialized when calling KafkaClusterConfig");
                 }
                 try {
-                    brokerKeytoolCertificateGenerator.generateSelfSignedCertificateEntry("test@redhat.com", clientEndpoint.getConnect().getHost(), "KI", "RedHat", null,
+                    brokerKeytoolCertificateGenerator.generateSelfSignedCertificateEntry("test@kroxylicious.io", clientEndpoint.getConnect().getHost(), "Dev", "Kroxylicious.io", null,
                             null,
                             "US");
                     if (clientKeytoolCertificateGenerator != null && Path.of(clientKeytoolCertificateGenerator.getCertFilePath()).toFile().exists()) {

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
@@ -199,7 +199,7 @@ public class KafkaClusterConfig {
 
                 var controllerEndpoint = kafkaEndpoints.getControllerEndpoint(brokerNum);
                 var quorumVoters = IntStream.range(0, kraftControllers)
-                        .mapToObj(b -> String.format("%d@//%s", b, kafkaEndpoints.getControllerEndpoint(b).connectAddress()))
+                        .mapToObj(controllerId -> String.format("%d@//%s", controllerId, kafkaEndpoints.getControllerEndpoint(controllerId).connectAddress()))
                         .collect(Collectors.joining(","));
                 putConfig(server, "controller.quorum.voters", quorumVoters);
                 putConfig(server, "controller.listener.names", "CONTROLLER");
@@ -248,7 +248,8 @@ public class KafkaClusterConfig {
                     throw new RuntimeException("brokerKeytoolCertificateGenerator needs to be initialized when calling KafkaClusterConfig");
                 }
                 try {
-                    brokerKeytoolCertificateGenerator.generateSelfSignedCertificateEntry("test@kroxylicious.io", clientEndpoint.getConnect().getHost(), "Dev", "Kroxylicious.io", null,
+                    brokerKeytoolCertificateGenerator.generateSelfSignedCertificateEntry("test@kroxylicious.io", clientEndpoint.getConnect().getHost(), "Dev",
+                            "Kroxylicious.io", null,
                             null,
                             "US");
                     if (clientKeytoolCertificateGenerator != null && Path.of(clientKeytoolCertificateGenerator.getCertFilePath()).toFile().exists()) {

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterFactory.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterFactory.java
@@ -5,10 +5,11 @@
  */
 package io.kroxylicious.testing.kafka.common;
 
+import org.testcontainers.utility.DockerImageName;
+
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.invm.InVMKafkaCluster;
 import io.kroxylicious.testing.kafka.testcontainers.TestcontainersKafkaCluster;
-import org.testcontainers.utility.DockerImageName;
 
 import static java.lang.System.Logger.Level.INFO;
 

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KeytoolCertificateGenerator.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KeytoolCertificateGenerator.java
@@ -41,10 +41,10 @@ public class KeytoolCertificateGenerator {
         this.trustStoreFilePath = (trustStorePath != null) ? Path.of(trustStorePath) : Paths.get(certsDirectory.toAbsolutePath().toString(), "kafka.truststore.jks");
 
         certsDirectory.toFile().deleteOnExit();
-        if(certFilePath == null) {
+        if (certFilePath == null) {
             this.keyStoreFilePath.toFile().deleteOnExit();
         }
-        if(trustStorePath == null) {
+        if (trustStorePath == null) {
             this.trustStoreFilePath.toFile().deleteOnExit();
         }
         this.certFilePath.toFile().deleteOnExit();
@@ -79,7 +79,7 @@ public class KeytoolCertificateGenerator {
 
     public void generateTrustStore(String certFilePath, String alias, String trustStoreFilePath)
             throws GeneralSecurityException, IOException {
-        //keytool -import -trustcacerts -keystore truststore.jks -storepass password -noprompt -alias localhost -file cert.crt
+        // keytool -import -trustcacerts -keystore truststore.jks -storepass password -noprompt -alias localhost -file cert.crt
         KeyStore keyStore = KeyStore.getInstance("JKS");
         if (Path.of(trustStoreFilePath).toFile().exists()) {
             keyStore.load(new FileInputStream(trustStoreFilePath), getPassword().toCharArray());
@@ -164,7 +164,7 @@ public class KeytoolCertificateGenerator {
             final String processOutput = (new BufferedReader(new InputStreamReader(process.getInputStream()))).lines()
                     .collect(Collectors.joining(" \\ "));
             log.log(WARNING, "Error generating certificate, error output: {0}, normal output: {1}, " +
-                            "commandline parameters: {2}",
+                    "commandline parameters: {2}",
                     processError, processOutput, commandParameters);
             throw new IOException(
                     "Keytool execution error: '" + processError + "', output: '" + processOutput + "'" + ", commandline parameters: " + commandParameters);

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/Utils.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/Utils.java
@@ -51,27 +51,28 @@ public class Utils {
     }
 
     public static void ensureExpectedBrokerCountInCluster(Map<String, Object> connectionConfig, int timeout, TimeUnit timeUnit, Integer expectedBrokerCount) {
-        final Admin admin = Admin.create(connectionConfig);
-        Awaitility.await()
-                .pollDelay(Duration.ZERO)
-                .pollInterval(1, TimeUnit.SECONDS)
-                .atMost(timeout, timeUnit)
-                .ignoreExceptions()
-                .until(() -> {
-                    log.info("describing cluster: {}", connectionConfig.get("bootstrap.servers"));
-                    final Collection<Node> nodes;
-                    try {
-                        nodes = admin.describeCluster().nodes().get(10, TimeUnit.SECONDS);
-                        log.info("got nodes: {}" + nodes);
-                        return nodes;
-                    }
-                    catch (InterruptedException | ExecutionException e) {
-                        log.warn("caught: {}", e.getMessage(), e);
-                    }
-                    catch (TimeoutException te) {
-                        log.warn("Kafka timed out describing the the cluster");
-                    }
-                    return Collections.emptyList();
-                }, Matchers.hasSize(expectedBrokerCount));
+        try(Admin admin = Admin.create(connectionConfig)) {
+            Awaitility.await()
+                    .pollDelay(Duration.ZERO)
+                    .pollInterval(1, TimeUnit.SECONDS)
+                    .atMost(timeout, timeUnit)
+                    .ignoreExceptions()
+                    .until(() -> {
+                        log.debug("describing cluster: {}", connectionConfig.get("bootstrap.servers"));
+                        final Collection<Node> nodes;
+                        try {
+                            nodes = admin.describeCluster().nodes().get(10, TimeUnit.SECONDS);
+                            log.debug("got nodes: {}", nodes);
+                            return nodes;
+                        }
+                        catch (InterruptedException | ExecutionException e) {
+                            log.warn("caught: {}", e.getMessage(), e);
+                        }
+                        catch (TimeoutException te) {
+                            log.warn("Kafka timed out describing the the cluster");
+                        }
+                        return Collections.emptyList();
+                    }, Matchers.hasSize(expectedBrokerCount));
+        }
     }
 }

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/Utils.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/Utils.java
@@ -6,6 +6,12 @@
 
 package io.kroxylicious.testing.kafka.common;
 
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.common.Node;
+import org.awaitility.Awaitility;
+import org.hamcrest.Matchers;
+import org.slf4j.Logger;
+
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.ServerSocket;
@@ -17,12 +23,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Stream;
-
-import org.apache.kafka.clients.admin.Admin;
-import org.apache.kafka.common.Node;
-import org.awaitility.Awaitility;
-import org.hamcrest.Matchers;
-import org.slf4j.Logger;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -50,7 +50,7 @@ public class Utils {
         }
     }
 
-    public static void ensureExpectedBrokerCountInCluster(Map<String, Object> connectionConfig, int timeout, TimeUnit timeUnit, Integer expectedBrokerCount) {
+    public static void awaitExpectedBrokerCountInCluster(Map<String, Object> connectionConfig, int timeout, TimeUnit timeUnit, Integer expectedBrokerCount) {
         try (Admin admin = Admin.create(connectionConfig)) {
             Awaitility.await()
                     .pollDelay(Duration.ZERO)

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/Utils.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/Utils.java
@@ -6,12 +6,6 @@
 
 package io.kroxylicious.testing.kafka.common;
 
-import org.apache.kafka.clients.admin.Admin;
-import org.apache.kafka.common.Node;
-import org.awaitility.Awaitility;
-import org.hamcrest.Matchers;
-import org.slf4j.Logger;
-
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.ServerSocket;
@@ -23,6 +17,12 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Stream;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.common.Node;
+import org.awaitility.Awaitility;
+import org.hamcrest.Matchers;
+import org.slf4j.Logger;
 
 import static org.slf4j.LoggerFactory.getLogger;
 
@@ -67,7 +67,8 @@ public class Utils {
                     }
                     catch (InterruptedException | ExecutionException e) {
                         log.warn("caught: {}", e.getMessage(), e);
-                    } catch (TimeoutException te) {
+                    }
+                    catch (TimeoutException te) {
                         log.warn("Kafka timed out describing the the cluster");
                     }
                     return Collections.emptyList();

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/Utils.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/Utils.java
@@ -6,12 +6,29 @@
 
 package io.kroxylicious.testing.kafka.common;
 
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.common.Node;
+import org.awaitility.Awaitility;
+import org.hamcrest.Matchers;
+import org.slf4j.Logger;
+
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.ServerSocket;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Stream;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
 public class Utils {
+    private static final Logger log = getLogger(Utils.class);
+
     /**
      * Pre-allocate 1 or more ephemeral ports which are available for use.
      *
@@ -31,5 +48,29 @@ public class Utils {
         catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    public static void ensureExpectedBrokerCountInCluster(Map<String, Object> connectionConfig, int timeout, TimeUnit timeUnit, Integer expectedBrokerCount) {
+        final Admin admin = Admin.create(connectionConfig);
+        Awaitility.await()
+                .pollDelay(Duration.ZERO)
+                .pollInterval(1, TimeUnit.SECONDS)
+                .atMost(timeout, timeUnit)
+                .ignoreExceptions()
+                .until(() -> {
+                    log.info("describing cluster: {}", connectionConfig.get("bootstrap.servers"));
+                    final Collection<Node> nodes;
+                    try {
+                        nodes = admin.describeCluster().nodes().get(10, TimeUnit.SECONDS);
+                        log.info("got nodes: {}" + nodes);
+                        return nodes;
+                    }
+                    catch (InterruptedException | ExecutionException e) {
+                        log.warn("caught: {}", e.getMessage(), e);
+                    } catch (TimeoutException te) {
+                        log.warn("Kafka timed out describing the the cluster");
+                    }
+                    return Collections.emptyList();
+                }, Matchers.hasSize(expectedBrokerCount));
     }
 }

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/Utils.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/Utils.java
@@ -51,18 +51,18 @@ public class Utils {
     }
 
     public static void ensureExpectedBrokerCountInCluster(Map<String, Object> connectionConfig, int timeout, TimeUnit timeUnit, Integer expectedBrokerCount) {
-        try(Admin admin = Admin.create(connectionConfig)) {
+        try (Admin admin = Admin.create(connectionConfig)) {
             Awaitility.await()
                     .pollDelay(Duration.ZERO)
                     .pollInterval(1, TimeUnit.SECONDS)
                     .atMost(timeout, timeUnit)
                     .ignoreExceptions()
                     .until(() -> {
-                        log.debug("describing cluster: {}", connectionConfig.get("bootstrap.servers"));
+                        log.info("describing cluster: {}", connectionConfig.get("bootstrap.servers"));
                         final Collection<Node> nodes;
                         try {
                             nodes = admin.describeCluster().nodes().get(10, TimeUnit.SECONDS);
-                            log.debug("got nodes: {}", nodes);
+                            log.info("got nodes: {}", nodes);
                             return nodes;
                         }
                         catch (InterruptedException | ExecutionException e) {

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
@@ -6,6 +6,20 @@
 
 package io.kroxylicious.testing.kafka.invm;
 
+import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import io.kroxylicious.testing.kafka.common.KafkaClusterConfig;
+import io.kroxylicious.testing.kafka.common.Utils;
+import kafka.server.KafkaConfig;
+import kafka.server.KafkaRaftServer;
+import kafka.server.KafkaServer;
+import kafka.server.Server;
+import kafka.tools.StorageTool;
+import org.apache.kafka.common.utils.Time;
+import org.apache.zookeeper.server.ServerCnxnFactory;
+import org.apache.zookeeper.server.ZooKeeperServer;
+import org.jetbrains.annotations.NotNull;
+import scala.Option;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -19,21 +33,6 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-
-import org.apache.kafka.common.utils.Time;
-import org.apache.zookeeper.server.ServerCnxnFactory;
-import org.apache.zookeeper.server.ZooKeeperServer;
-import org.jetbrains.annotations.NotNull;
-
-import io.kroxylicious.testing.kafka.api.KafkaCluster;
-import io.kroxylicious.testing.kafka.common.KafkaClusterConfig;
-import io.kroxylicious.testing.kafka.common.Utils;
-import kafka.server.KafkaConfig;
-import kafka.server.KafkaRaftServer;
-import kafka.server.KafkaServer;
-import kafka.server.Server;
-import kafka.tools.StorageTool;
-import scala.Option;
 
 import static org.apache.kafka.server.common.MetadataVersion.MINIMUM_BOOTSTRAP_VERSION;
 
@@ -170,9 +169,7 @@ public class InVMKafkaCluster implements KafkaCluster {
         }
 
         servers.stream().parallel().forEach(Server::startup);
-        // TODO expose timeout. Annotations? Provisioning Strategy duration?
-        Utils.ensureExpectedBrokerCountInCluster(clusterConfig.getAnonConnectConfigForCluster(kafkaEndpoints), 120, TimeUnit.SECONDS, clusterConfig.getBrokersNum());
-
+        Utils.awaitExpectedBrokerCountInCluster(clusterConfig.getAnonConnectConfigForCluster(kafkaEndpoints), 120, TimeUnit.SECONDS, clusterConfig.getBrokersNum());
     }
 
     @Override

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
@@ -116,7 +116,6 @@ public class InVMKafkaCluster implements KafkaCluster {
 
     @NotNull
     private Server buildKafkaServer(KafkaClusterConfig.ConfigHolder c) {
-        bootstraps.add(c.getEndpoint());
         KafkaConfig config = buildBrokerConfig(c, tempDirectory);
         Option<String> threadNamePrefix = Option.apply(null);
 
@@ -159,6 +158,9 @@ public class InVMKafkaCluster implements KafkaCluster {
         }
 
         servers.stream().parallel().forEach(Server::startup);
+        // TODO expose timeout. Annotations? Provisioning Strategy duration?
+        final String bootstrapServers = clusterConfig.buildClientBootstrapServers(kafkaEndpoints);
+        Utils.ensureExpectedBrokerCountInCluster(clusterConfig.getConnectConfigForCluster(bootstrapServers), 120, TimeUnit.SECONDS, clusterConfig.getBrokersNum());
 
     }
 
@@ -188,7 +190,6 @@ public class InVMKafkaCluster implements KafkaCluster {
         try {
             try {
                 servers.stream().parallel().forEach(Server::shutdown);
-                bootstraps.clear();
             }
             finally {
                 if (zooServer != null) {

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
@@ -6,9 +6,6 @@
 
 package io.kroxylicious.testing.kafka.invm;
 
-import io.kroxylicious.testing.kafka.api.KafkaCluster;
-import io.kroxylicious.testing.kafka.common.KafkaClusterConfig;
-import io.kroxylicious.testing.kafka.common.Utils;
 import kafka.server.KafkaConfig;
 import kafka.server.KafkaRaftServer;
 import kafka.server.KafkaServer;
@@ -33,6 +30,10 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+
+import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import io.kroxylicious.testing.kafka.common.KafkaClusterConfig;
+import io.kroxylicious.testing.kafka.common.Utils;
 
 import static org.apache.kafka.server.common.MetadataVersion.MINIMUM_BOOTSTRAP_VERSION;
 

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
@@ -6,27 +6,12 @@
 
 package io.kroxylicious.testing.kafka.invm;
 
-import io.kroxylicious.testing.kafka.api.KafkaCluster;
-import io.kroxylicious.testing.kafka.common.KafkaClusterConfig;
-import io.kroxylicious.testing.kafka.common.Utils;
-import kafka.server.KafkaConfig;
-import kafka.server.KafkaRaftServer;
-import kafka.server.KafkaServer;
-import kafka.server.Server;
-import kafka.tools.StorageTool;
-import org.apache.kafka.common.utils.Time;
-import org.apache.zookeeper.server.ServerCnxnFactory;
-import org.apache.zookeeper.server.ZooKeeperServer;
-import org.jetbrains.annotations.NotNull;
-import scala.Option;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.InetSocketAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
@@ -35,6 +20,21 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+
+import org.apache.kafka.common.utils.Time;
+import org.apache.zookeeper.server.ServerCnxnFactory;
+import org.apache.zookeeper.server.ZooKeeperServer;
+import org.jetbrains.annotations.NotNull;
+
+import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import io.kroxylicious.testing.kafka.common.KafkaClusterConfig;
+import io.kroxylicious.testing.kafka.common.Utils;
+import kafka.server.KafkaConfig;
+import kafka.server.KafkaRaftServer;
+import kafka.server.KafkaServer;
+import kafka.server.Server;
+import kafka.tools.StorageTool;
+import scala.Option;
 
 import static org.apache.kafka.server.common.MetadataVersion.MINIMUM_BOOTSTRAP_VERSION;
 
@@ -73,7 +73,8 @@ public class InVMKafkaCluster implements KafkaCluster {
 
                 zooServer = new ZooKeeperServer(snapshotDir.toFile(), logDir.toFile(), 500);
                 zookeeperEndpointSupplier = () -> new KafkaClusterConfig.KafkaEndpoints.Endpoint("localhost", zookeeperPort);
-            } else {
+            }
+            else {
                 zooFactory = null;
                 zooServer = null;
                 zookeeperEndpointSupplier = null;

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
@@ -5,6 +5,21 @@
  */
 package io.kroxylicious.testing.kafka.testcontainers;
 
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import io.kroxylicious.testing.kafka.common.KafkaClusterConfig;
+import io.kroxylicious.testing.kafka.common.Utils;
+import lombok.SneakyThrows;
+import org.apache.kafka.common.config.SslConfigs;
+import org.junit.jupiter.api.TestInfo;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.output.OutputFrame;
+import org.testcontainers.images.builder.Transferable;
+import org.testcontainers.lifecycle.Startable;
+import org.testcontainers.lifecycle.Startables;
+import org.testcontainers.utility.DockerImageName;
+
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileWriter;
@@ -27,23 +42,6 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.apache.kafka.common.config.SslConfigs;
-import org.junit.jupiter.api.TestInfo;
-import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.Network;
-import org.testcontainers.containers.output.OutputFrame;
-import org.testcontainers.images.builder.Transferable;
-import org.testcontainers.lifecycle.Startable;
-import org.testcontainers.lifecycle.Startables;
-import org.testcontainers.utility.DockerImageName;
-
-import com.github.dockerjava.api.command.InspectContainerResponse;
-
-import io.kroxylicious.testing.kafka.api.KafkaCluster;
-import io.kroxylicious.testing.kafka.common.KafkaClusterConfig;
-import io.kroxylicious.testing.kafka.common.Utils;
-import lombok.SneakyThrows;
-
 import static io.kroxylicious.testing.kafka.common.Utils.ensureExpectedBrokerCountInCluster;
 
 /**
@@ -52,7 +50,8 @@ import static io.kroxylicious.testing.kafka.common.Utils.ensureExpectedBrokerCou
 public class TestcontainersKafkaCluster implements Startable, KafkaCluster {
 
     private static final System.Logger LOGGER = System.getLogger(TestcontainersKafkaCluster.class.getName());
-    public static final int KAFKA_PORT = 9093;
+    public static final int CLIENT_PORT = 9093;
+    public static final int ANON_PORT = 9094;
     public static final int ZOOKEEPER_PORT = 2181;
     private static final String QUAY_KAFKA_IMAGE_REPO = "quay.io/ogunalp/kafka-native";
     private static final String QUAY_ZOOKEEPER_IMAGE_REPO = "quay.io/ogunalp/zookeeper-native";
@@ -99,16 +98,22 @@ public class TestcontainersKafkaCluster implements Startable, KafkaCluster {
             this.zookeeper = new ZookeeperContainer(this.zookeeperImage)
                     .withName(name)
                     .withNetwork(network)
-                    // .withEnv("QUARKUS_LOG_LEVEL", "DEBUG") // Enables org.apache.zookeeper logging too
+//                    .withEnv("QUARKUS_LOG_LEVEL", "DEBUG") // Enables org.apache.zookeeper logging too
                     .withNetworkAliases("zookeeper");
         }
 
         kafkaEndpoints = new KafkaClusterConfig.KafkaEndpoints() {
             final List<Integer> clientPorts = Utils.preAllocateListeningPorts(clusterConfig.getBrokersNum()).collect(Collectors.toList());
+            final List<Integer> anonPorts = Utils.preAllocateListeningPorts(clusterConfig.getBrokersNum()).collect(Collectors.toList());
 
             @Override
             public EndpointPair getClientEndpoint(int brokerId) {
-                return EndpointPair.builder().bind(new Endpoint("0.0.0.0", 9093)).connect(new Endpoint("localhost", clientPorts.get(brokerId))).build();
+                return buildExposedEndpoint(brokerId, CLIENT_PORT, clientPorts);
+            }
+
+            @Override
+            public EndpointPair getAnonEndpoint(int brokerId) {
+                return buildExposedEndpoint(brokerId, ANON_PORT, anonPorts);
             }
 
             @Override
@@ -119,6 +124,13 @@ public class TestcontainersKafkaCluster implements Startable, KafkaCluster {
             @Override
             public EndpointPair getControllerEndpoint(int brokerId) {
                 return EndpointPair.builder().bind(new Endpoint("0.0.0.0", 9091)).connect(new Endpoint(String.format("broker-%d", brokerId), 9091)).build();
+            }
+
+            private EndpointPair buildExposedEndpoint(int brokerId, int internalPort, List<Integer> externalPortRange) {
+                return EndpointPair.builder()
+                        .bind(new Endpoint("0.0.0.0", internalPort))
+                        .connect(new Endpoint("localhost", externalPortRange.get(brokerId)))
+                        .build();
             }
         };
 
@@ -136,12 +148,13 @@ public class TestcontainersKafkaCluster implements Startable, KafkaCluster {
             copyHostKeyStoreToContainer(kafkaContainer, holder.getProperties(), SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG);
 
             kafkaContainer
-                    // .withEnv("QUARKUS_LOG_LEVEL", "DEBUG") // Enables org.apache.kafka logging too
+//                    .withEnv("QUARKUS_LOG_LEVEL", "DEBUG") // Enables org.apache.kafka logging too
                     .withEnv("SERVER_PROPERTIES_FILE", "/cnf/server.properties")
                     .withEnv("SERVER_CLUSTER_ID", holder.getKafkaKraftClusterId())
                     .withCopyToContainer(Transferable.of(propertiesToBytes(holder.getProperties()), 0644), "/cnf/server.properties")
                     .withStartupTimeout(Duration.ofMinutes(2));
-            kafkaContainer.addFixedExposedPort(holder.getExternalPort(), KAFKA_PORT);
+            kafkaContainer.addFixedExposedPort(holder.getExternalPort(), CLIENT_PORT);
+            kafkaContainer.addFixedExposedPort(holder.getAnonPort(), ANON_PORT);
 
             if (!this.clusterConfig.isKraftMode()) {
                 kafkaContainer.dependsOn(this.zookeeper);
@@ -202,7 +215,7 @@ public class TestcontainersKafkaCluster implements Startable, KafkaCluster {
                 zookeeper.start();
             }
             Startables.deepStart(brokers.stream()).get(READY_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-            ensureExpectedBrokerCountInCluster(clusterConfig.getConnectConfigForCluster(getBootstrapServers()), READY_TIMEOUT_SECONDS, TimeUnit.SECONDS,
+            ensureExpectedBrokerCountInCluster(clusterConfig.getAnonConnectConfigForCluster(kafkaEndpoints), READY_TIMEOUT_SECONDS, TimeUnit.SECONDS,
                     clusterConfig.getBrokersNum());
         }
         catch (InterruptedException | ExecutionException | TimeoutException e) {
@@ -236,8 +249,7 @@ public class TestcontainersKafkaCluster implements Startable, KafkaCluster {
 
     @Override
     public Map<String, Object> getKafkaClientConfiguration(String user, String password) {
-        return clusterConfig.getConnectConfigForCluster(getBootstrapServers(),
-                user, password);
+        return clusterConfig.getConnectConfigForCluster(getBootstrapServers(), user, password);
     }
 
     // In kraft mode, currently "Advertised listeners cannot be altered when using a Raft-based metadata quorum", so we

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
@@ -202,7 +202,8 @@ public class TestcontainersKafkaCluster implements Startable, KafkaCluster {
                 zookeeper.start();
             }
             Startables.deepStart(brokers.stream()).get(READY_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-            ensureExpectedBrokerCountInCluster(clusterConfig.getConnectConfigForCluster(getBootstrapServers()), READY_TIMEOUT_SECONDS, TimeUnit.SECONDS, clusterConfig.getBrokersNum());
+            ensureExpectedBrokerCountInCluster(clusterConfig.getConnectConfigForCluster(getBootstrapServers()), READY_TIMEOUT_SECONDS, TimeUnit.SECONDS,
+                    clusterConfig.getBrokersNum());
         }
         catch (InterruptedException | ExecutionException | TimeoutException e) {
             if (e instanceof InterruptedException) {

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
@@ -6,9 +6,6 @@
 package io.kroxylicious.testing.kafka.testcontainers;
 
 import com.github.dockerjava.api.command.InspectContainerResponse;
-import io.kroxylicious.testing.kafka.api.KafkaCluster;
-import io.kroxylicious.testing.kafka.common.KafkaClusterConfig;
-import io.kroxylicious.testing.kafka.common.Utils;
 import lombok.SneakyThrows;
 import org.apache.kafka.common.config.SslConfigs;
 import org.junit.jupiter.api.TestInfo;
@@ -41,6 +38,10 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import io.kroxylicious.testing.kafka.common.KafkaClusterConfig;
+import io.kroxylicious.testing.kafka.common.Utils;
 
 import static io.kroxylicious.testing.kafka.common.Utils.awaitExpectedBrokerCountInCluster;
 

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
@@ -42,7 +42,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static io.kroxylicious.testing.kafka.common.Utils.ensureExpectedBrokerCountInCluster;
+import static io.kroxylicious.testing.kafka.common.Utils.awaitExpectedBrokerCountInCluster;
 
 /**
  * Provides an easy way to launch a Kafka cluster with multiple brokers in a container
@@ -215,7 +215,7 @@ public class TestcontainersKafkaCluster implements Startable, KafkaCluster {
                 zookeeper.start();
             }
             Startables.deepStart(brokers.stream()).get(READY_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-            ensureExpectedBrokerCountInCluster(clusterConfig.getAnonConnectConfigForCluster(kafkaEndpoints), READY_TIMEOUT_SECONDS, TimeUnit.SECONDS,
+            awaitExpectedBrokerCountInCluster(clusterConfig.getAnonConnectConfigForCluster(kafkaEndpoints), READY_TIMEOUT_SECONDS, TimeUnit.SECONDS,
                     clusterConfig.getBrokersNum());
         }
         catch (InterruptedException | ExecutionException | TimeoutException e) {

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
@@ -44,6 +44,8 @@ import io.kroxylicious.testing.kafka.common.KafkaClusterConfig;
 import io.kroxylicious.testing.kafka.common.Utils;
 import lombok.SneakyThrows;
 
+import static io.kroxylicious.testing.kafka.common.Utils.ensureExpectedBrokerCountInCluster;
+
 /**
  * Provides an easy way to launch a Kafka cluster with multiple brokers in a container
  */
@@ -200,6 +202,7 @@ public class TestcontainersKafkaCluster implements Startable, KafkaCluster {
                 zookeeper.start();
             }
             Startables.deepStart(brokers.stream()).get(READY_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+            ensureExpectedBrokerCountInCluster(clusterConfig.getConnectConfigForCluster(getBootstrapServers()), READY_TIMEOUT_SECONDS, TimeUnit.SECONDS, clusterConfig.getBrokersNum());
         }
         catch (InterruptedException | ExecutionException | TimeoutException e) {
             if (e instanceof InterruptedException) {

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/KafkaClusterTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/KafkaClusterTest.java
@@ -6,8 +6,6 @@
 package io.kroxylicious.testing.kafka;
 
 import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.security.GeneralSecurityException;
 import java.time.Duration;
 import java.util.List;
@@ -25,7 +23,6 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/KafkaClusterTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/KafkaClusterTest.java
@@ -5,10 +5,6 @@
  */
 package io.kroxylicious.testing.kafka;
 
-import io.kroxylicious.testing.kafka.api.KafkaCluster;
-import io.kroxylicious.testing.kafka.common.KafkaClusterConfig;
-import io.kroxylicious.testing.kafka.common.KafkaClusterFactory;
-import io.kroxylicious.testing.kafka.common.KeytoolCertificateGenerator;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.DescribeClusterResult;
 import org.apache.kafka.clients.admin.KafkaAdminClient;
@@ -30,6 +26,11 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import io.kroxylicious.testing.kafka.common.KafkaClusterConfig;
+import io.kroxylicious.testing.kafka.common.KafkaClusterFactory;
+import io.kroxylicious.testing.kafka.common.KeytoolCertificateGenerator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.testcontainers.shaded.org.awaitility.Awaitility.await;

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/KafkaClusterTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/KafkaClusterTest.java
@@ -5,13 +5,10 @@
  */
 package io.kroxylicious.testing.kafka;
 
-import java.io.IOException;
-import java.security.GeneralSecurityException;
-import java.time.Duration;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
+import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import io.kroxylicious.testing.kafka.common.KafkaClusterConfig;
+import io.kroxylicious.testing.kafka.common.KafkaClusterFactory;
+import io.kroxylicious.testing.kafka.common.KeytoolCertificateGenerator;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.DescribeClusterResult;
 import org.apache.kafka.clients.admin.KafkaAdminClient;
@@ -27,10 +24,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
-import io.kroxylicious.testing.kafka.api.KafkaCluster;
-import io.kroxylicious.testing.kafka.common.KafkaClusterConfig;
-import io.kroxylicious.testing.kafka.common.KafkaClusterFactory;
-import io.kroxylicious.testing.kafka.common.KeytoolCertificateGenerator;
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
@@ -302,6 +301,6 @@ public class KafkaClusterTest {
 
     private void createClientCertificate() throws GeneralSecurityException, IOException {
         this.clientKeytoolCertificateGenerator = new KeytoolCertificateGenerator();
-        this.clientKeytoolCertificateGenerator.generateSelfSignedCertificateEntry("clientTest@redhat.com", "client", "KI", "Red Hat", null, null, "US");
+        this.clientKeytoolCertificateGenerator.generateSelfSignedCertificateEntry("clientTest@kroxylicious.io", "client", "Dev", "Kroxylicious.ip", null, null, "US");
     }
 }

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfigTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfigTest.java
@@ -1,0 +1,146 @@
+package io.kroxylicious.testing.kafka.common;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KafkaClusterConfigTest {
+
+
+    private static final int CLIENT_BASE_PORT = 9092;
+    private static final int CONTROLLER_BASE_PORT = 10092;
+    private static final int INTER_BROKER_BASE_PORT = 11092;
+    private EndpointConfig endpointConfig;
+    private KafkaClusterConfig.KafkaClusterConfigBuilder kafkaClusterConfigBuilder;
+
+    @BeforeEach
+    void setUp(TestInfo testInfo) {
+        endpointConfig = new EndpointConfig();
+        kafkaClusterConfigBuilder = KafkaClusterConfig.builder();
+        kafkaClusterConfigBuilder.testInfo(testInfo);
+    }
+
+    @Test
+    void shouldBuildClientBootstrapAddressForSingleBroker() {
+        //Given
+        kafkaClusterConfigBuilder.brokersNum(1);
+        final KafkaClusterConfig kafkaClusterConfig = kafkaClusterConfigBuilder.build();
+
+        //When
+        final String clientBootstrapServers = kafkaClusterConfig.buildClientBootstrapServers(endpointConfig);
+
+        //Then
+        assertThat(clientBootstrapServers).doesNotContain(",");
+        assertThat(clientBootstrapServers).doesNotContain("//");
+        assertThat(clientBootstrapServers).contains("localhost:9092");
+    }
+
+    @Test
+    void shouldBuildClientBootstrapAddressForCluster() {
+        //Given
+        kafkaClusterConfigBuilder.brokersNum(3);
+        final KafkaClusterConfig kafkaClusterConfig = kafkaClusterConfigBuilder.build();
+
+        //When
+        final String clientBootstrapServers = kafkaClusterConfig.buildClientBootstrapServers(endpointConfig);
+
+        //Then
+        assertThat(clientBootstrapServers).contains(",");
+        assertThat(clientBootstrapServers).doesNotContain("//");
+        assertThat(clientBootstrapServers).contains("localhost:9092");
+        assertThat(clientBootstrapServers).contains("localhost:9093");
+        assertThat(clientBootstrapServers).contains("localhost:9094");
+    }
+    
+    @Test
+    void shouldBuildInterBrokerBootstrapAddressForSingleBroker() {
+        //Given
+        kafkaClusterConfigBuilder.brokersNum(1);
+        final KafkaClusterConfig kafkaClusterConfig = kafkaClusterConfigBuilder.build();
+
+        //When
+        final String interBrokerBootstrapServers = kafkaClusterConfig.buildInterBrokerBootstrapServers(endpointConfig);
+
+        //Then
+        assertThat(interBrokerBootstrapServers).doesNotContain(",");
+        assertThat(interBrokerBootstrapServers).doesNotContain("//");
+        assertThat(interBrokerBootstrapServers).contains("localhost:11092");
+    }
+
+    @Test
+    void shouldBuildInterBrokerBootstrapAddressForCluster() {
+        //Given
+        kafkaClusterConfigBuilder.brokersNum(3);
+        final KafkaClusterConfig kafkaClusterConfig = kafkaClusterConfigBuilder.build();
+
+        //When
+        final String interBrokerBootstrapServers = kafkaClusterConfig.buildInterBrokerBootstrapServers(endpointConfig);
+
+        //Then
+        assertThat(interBrokerBootstrapServers).contains(",");
+        assertThat(interBrokerBootstrapServers).doesNotContain("//");
+        assertThat(interBrokerBootstrapServers).contains("localhost:11092");
+        assertThat(interBrokerBootstrapServers).contains("localhost:11093");
+        assertThat(interBrokerBootstrapServers).contains("localhost:11094");
+    }
+
+    @Test
+    void shouldBuildControllerBootstrapAddressForSingleBroker() {
+        //Given
+        kafkaClusterConfigBuilder.brokersNum(1);
+        final KafkaClusterConfig kafkaClusterConfig = kafkaClusterConfigBuilder.build();
+
+        //When
+        final String controllerBootstrapServers = kafkaClusterConfig.buildControllerBootstrapServers(endpointConfig);
+
+        //Then
+        assertThat(controllerBootstrapServers).doesNotContain(",");
+        assertThat(controllerBootstrapServers).doesNotContain("//");
+        assertThat(controllerBootstrapServers).contains("localhost:10092");
+    }
+
+    @Test
+    void shouldBuildControllerBootstrapAddressForCluster() {
+        //Given
+
+        kafkaClusterConfigBuilder.brokersNum(3);
+        final KafkaClusterConfig kafkaClusterConfig = kafkaClusterConfigBuilder.build();
+
+        //When
+        final String controllerBootstrapServers = kafkaClusterConfig.buildControllerBootstrapServers(endpointConfig);
+
+        //Then
+        assertThat(controllerBootstrapServers).contains(",");
+        assertThat(controllerBootstrapServers).doesNotContain("//");
+        assertThat(controllerBootstrapServers).contains("localhost:10092");
+        assertThat(controllerBootstrapServers).contains("localhost:10093");
+        assertThat(controllerBootstrapServers).contains("localhost:10094");
+    }
+
+    static class EndpointConfig implements KafkaClusterConfig.KafkaEndpoints {
+
+        @Override
+        public EndpointPair getInterBrokerEndpoint(int brokerId) {
+            return generateEndpoint(brokerId, INTER_BROKER_BASE_PORT);
+        }
+
+        @Override
+        public EndpointPair getControllerEndpoint(int brokerId) {
+            return generateEndpoint(brokerId, CONTROLLER_BASE_PORT);
+        }
+
+        @Override
+        public EndpointPair getClientEndpoint(int brokerId) {
+            return generateEndpoint(brokerId, CLIENT_BASE_PORT);
+        }
+
+        @NotNull
+        private static EndpointPair generateEndpoint(int brokerId, int basePort) {
+            final int port = basePort + brokerId;
+            return new EndpointPair(new Endpoint("0.0.0.0", port), new Endpoint("localhost", port));
+        }
+    }
+}

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfigTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfigTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.kroxylicious.testing.kafka.common;
 
 import org.jetbrains.annotations.NotNull;
@@ -8,7 +13,6 @@ import org.junit.jupiter.api.TestInfo;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class KafkaClusterConfigTest {
-
 
     private static final int CLIENT_BASE_PORT = 9092;
     private static final int CONTROLLER_BASE_PORT = 10092;
@@ -25,14 +29,14 @@ class KafkaClusterConfigTest {
 
     @Test
     void shouldBuildClientBootstrapAddressForSingleBroker() {
-        //Given
+        // Given
         kafkaClusterConfigBuilder.brokersNum(1);
         final KafkaClusterConfig kafkaClusterConfig = kafkaClusterConfigBuilder.build();
 
-        //When
+        // When
         final String clientBootstrapServers = kafkaClusterConfig.buildClientBootstrapServers(endpointConfig);
 
-        //Then
+        // Then
         assertThat(clientBootstrapServers).doesNotContain(",");
         assertThat(clientBootstrapServers).doesNotContain("//");
         assertThat(clientBootstrapServers).contains("localhost:9092");
@@ -40,31 +44,31 @@ class KafkaClusterConfigTest {
 
     @Test
     void shouldBuildClientBootstrapAddressForCluster() {
-        //Given
+        // Given
         kafkaClusterConfigBuilder.brokersNum(3);
         final KafkaClusterConfig kafkaClusterConfig = kafkaClusterConfigBuilder.build();
 
-        //When
+        // When
         final String clientBootstrapServers = kafkaClusterConfig.buildClientBootstrapServers(endpointConfig);
 
-        //Then
+        // Then
         assertThat(clientBootstrapServers).contains(",");
         assertThat(clientBootstrapServers).doesNotContain("//");
         assertThat(clientBootstrapServers).contains("localhost:9092");
         assertThat(clientBootstrapServers).contains("localhost:9093");
         assertThat(clientBootstrapServers).contains("localhost:9094");
     }
-    
+
     @Test
     void shouldBuildInterBrokerBootstrapAddressForSingleBroker() {
-        //Given
+        // Given
         kafkaClusterConfigBuilder.brokersNum(1);
         final KafkaClusterConfig kafkaClusterConfig = kafkaClusterConfigBuilder.build();
 
-        //When
+        // When
         final String interBrokerBootstrapServers = kafkaClusterConfig.buildInterBrokerBootstrapServers(endpointConfig);
 
-        //Then
+        // Then
         assertThat(interBrokerBootstrapServers).doesNotContain(",");
         assertThat(interBrokerBootstrapServers).doesNotContain("//");
         assertThat(interBrokerBootstrapServers).contains("localhost:11092");
@@ -72,14 +76,14 @@ class KafkaClusterConfigTest {
 
     @Test
     void shouldBuildInterBrokerBootstrapAddressForCluster() {
-        //Given
+        // Given
         kafkaClusterConfigBuilder.brokersNum(3);
         final KafkaClusterConfig kafkaClusterConfig = kafkaClusterConfigBuilder.build();
 
-        //When
+        // When
         final String interBrokerBootstrapServers = kafkaClusterConfig.buildInterBrokerBootstrapServers(endpointConfig);
 
-        //Then
+        // Then
         assertThat(interBrokerBootstrapServers).contains(",");
         assertThat(interBrokerBootstrapServers).doesNotContain("//");
         assertThat(interBrokerBootstrapServers).contains("localhost:11092");
@@ -89,14 +93,14 @@ class KafkaClusterConfigTest {
 
     @Test
     void shouldBuildControllerBootstrapAddressForSingleBroker() {
-        //Given
+        // Given
         kafkaClusterConfigBuilder.brokersNum(1);
         final KafkaClusterConfig kafkaClusterConfig = kafkaClusterConfigBuilder.build();
 
-        //When
+        // When
         final String controllerBootstrapServers = kafkaClusterConfig.buildControllerBootstrapServers(endpointConfig);
 
-        //Then
+        // Then
         assertThat(controllerBootstrapServers).doesNotContain(",");
         assertThat(controllerBootstrapServers).doesNotContain("//");
         assertThat(controllerBootstrapServers).contains("localhost:10092");
@@ -104,15 +108,15 @@ class KafkaClusterConfigTest {
 
     @Test
     void shouldBuildControllerBootstrapAddressForCluster() {
-        //Given
+        // Given
 
         kafkaClusterConfigBuilder.brokersNum(3);
         final KafkaClusterConfig kafkaClusterConfig = kafkaClusterConfigBuilder.build();
 
-        //When
+        // When
         final String controllerBootstrapServers = kafkaClusterConfig.buildControllerBootstrapServers(endpointConfig);
 
-        //Then
+        // Then
         assertThat(controllerBootstrapServers).contains(",");
         assertThat(controllerBootstrapServers).doesNotContain("//");
         assertThat(controllerBootstrapServers).contains("localhost:10092");

--- a/junit5-extension/pom.xml
+++ b/junit5-extension/pom.xml
@@ -44,7 +44,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>

--- a/junit5-extension/src/main/java/io/kroxylicious/testing/kafka/junit5ext/KafkaClusterExtension.java
+++ b/junit5-extension/src/main/java/io/kroxylicious/testing/kafka/junit5ext/KafkaClusterExtension.java
@@ -5,28 +5,6 @@
  */
 package io.kroxylicious.testing.kafka.junit5ext;
 
-import java.lang.annotation.Annotation;
-import java.lang.reflect.AnnotatedElement;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.lang.reflect.Parameter;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Base64;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Objects;
-import java.util.ServiceLoader;
-import java.util.UUID;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -74,6 +52,28 @@ import org.junit.platform.commons.support.AnnotationSupport;
 import org.junit.platform.commons.support.HierarchyTraversalMode;
 import org.junit.platform.commons.util.ExceptionUtils;
 import org.junit.platform.commons.util.ReflectionUtils;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.ServiceLoader;
+import java.util.UUID;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.api.KafkaClusterConstraint;

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/AbstractExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/AbstractExtensionTest.java
@@ -5,15 +5,15 @@
  */
 package io.kroxylicious.testing.kafka.junit5ext;
 
-import java.util.Map;
-import java.util.concurrent.ExecutionException;
-
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.DescribeClusterResult;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
 
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/InstanceFieldExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/InstanceFieldExtensionTest.java
@@ -5,11 +5,11 @@
  */
 package io.kroxylicious.testing.kafka.junit5ext;
 
-import java.util.concurrent.ExecutionException;
-
 import org.apache.kafka.clients.admin.Admin;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.concurrent.ExecutionException;
 
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.common.BrokerCluster;

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/ParameterExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/ParameterExtensionTest.java
@@ -5,17 +5,18 @@
  */
 package io.kroxylicious.testing.kafka.junit5ext;
 
-import java.time.Duration;
-import java.util.List;
-import java.util.concurrent.ExecutionException;
-import java.util.regex.Pattern;
-
+import kafka.server.KafkaConfig;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.SaslAuthenticationException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.regex.Pattern;
 
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.common.BrokerCluster;
@@ -25,7 +26,6 @@ import io.kroxylicious.testing.kafka.common.SaslPlainAuth;
 import io.kroxylicious.testing.kafka.common.Tls;
 import io.kroxylicious.testing.kafka.common.ZooKeeperCluster;
 import io.kroxylicious.testing.kafka.invm.InVMKafkaCluster;
-import kafka.server.KafkaConfig;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/StaticFieldExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/StaticFieldExtensionTest.java
@@ -5,8 +5,6 @@
  */
 package io.kroxylicious.testing.kafka.junit5ext;
 
-import java.util.concurrent.ExecutionException;
-
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.KafkaAdminClient;
@@ -17,6 +15,8 @@ import org.apache.kafka.clients.producer.Producer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.concurrent.ExecutionException;
 
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.common.BrokerCluster;

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/StaticFieldSubclassExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/StaticFieldSubclassExtensionTest.java
@@ -5,8 +5,6 @@
  */
 package io.kroxylicious.testing.kafka.junit5ext;
 
-import java.util.concurrent.ExecutionException;
-
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.KafkaAdminClient;
@@ -16,6 +14,8 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.concurrent.ExecutionException;
 
 import io.kroxylicious.testing.kafka.common.BrokerCluster;
 import io.kroxylicious.testing.kafka.testcontainers.TestcontainersKafkaCluster;

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/TemplateTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/TemplateTest.java
@@ -5,6 +5,14 @@
  */
 package io.kroxylicious.testing.kafka.junit5ext;
 
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.Config;
+import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.errors.UnsupportedVersionException;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
 import java.lang.annotation.Annotation;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -14,14 +22,6 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Stream;
 
-import org.apache.kafka.clients.admin.Admin;
-import org.apache.kafka.clients.admin.Config;
-import org.apache.kafka.common.config.ConfigResource;
-import org.apache.kafka.common.errors.UnsupportedVersionException;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.TestTemplate;
-import org.junit.jupiter.api.extension.ExtendWith;
-
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.common.BrokerCluster;
 import io.kroxylicious.testing.kafka.common.BrokerConfig;
@@ -29,7 +29,11 @@ import io.kroxylicious.testing.kafka.common.KRaftCluster;
 import io.kroxylicious.testing.kafka.common.Version;
 import io.kroxylicious.testing.kafka.testcontainers.TestcontainersKafkaCluster;
 
-import static io.kroxylicious.testing.kafka.common.ConstraintUtils.*;
+import static io.kroxylicious.testing.kafka.common.ConstraintUtils.brokerCluster;
+import static io.kroxylicious.testing.kafka.common.ConstraintUtils.brokerConfig;
+import static io.kroxylicious.testing.kafka.common.ConstraintUtils.kraftCluster;
+import static io.kroxylicious.testing.kafka.common.ConstraintUtils.version;
+import static io.kroxylicious.testing.kafka.common.ConstraintUtils.zooKeeperCluster;
 import static io.kroxylicious.testing.kafka.junit5ext.AbstractExtensionTest.assertSameCluster;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,6 @@
                 <groupId>org.awaitility</groupId>
                 <artifactId>awaitility</artifactId>
                 <version>${awaitility.version}</version>
-                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.assertj</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -401,6 +401,12 @@
                                 <phase>process-sources</phase>
                             </execution>
                         </executions>
+                        <configuration>
+                            <groups>java.,javax.,org.,com.,io.,io.kroxylicious.</groups>
+                            <removeUnused>true</removeUnused>
+                            <staticAfter>true</staticAfter>
+                            <compliance>${java.test.version}</compliance>
+                        </configuration>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
 Uses an admin client to describe the cluster and ensure the expected number of brokers are included before injecting into tests. 
 
 The one snag this faces is when authentication comes into play. 
 
 Initially I tried to connect to the inter-broker listener however that's not currently exposed to the host when running in test containers. So switched back to using the client listener. When that is authenticated the default admin client is unable to connect. 
 
 I see three possible solutions.

1. Always generate an additional "admin" account which the extension can use to connect
2. Ensure the inter broker listener is exposed outside of the VM network
3.  Create an additional listener without authentication requirements for the admin client to connect too.

Separately I think there is some additional refactoring to do around how endpoints are defined and used to generate the various different formats of host and port required. i.e. clients don't like resolving `//localhost:9093` and listeners don't like `localhost:9093`. 

Fixes #7 