### PR TITLE
Added getNumOfBrokers method in KafkaCluster interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,3 +223,18 @@ This will produce tests as follows:
 Provisioning mechanisms can be provided externally by implementing `io.kroxylicious.testing.kafka.api.KafkaClusterProvisioningStrategy` and declaring it as a [Java service](https://www.baeldung.com/java-spi) (e.g. in a  `META-INF/services/io.kroxylicious.testing.kafka.api.KafkaClusterProvisioningStrategy` file that is available on the test-time classpath).
 
 You can also provide your own constraint annotation types by annotating them with the `@io.kroxylicious.testing.kafka.api.KafkaClusterConstraint` meta-annotation. Such custom constraint annotations will only be understood by your custom provisioning strategy, so the in-JVM and testcontainers-based clusters provided by this project then can't be used.
+
+## Compilation with format validator
+
+As the project should follow the same format for all the files, in case a format error is detected when running the `ci` profile:
+
+```shell
+mvn clean verify -Pci
+```
+
+the following commands shall be run to fix those format issues: 
+
+```shell
+mvn compile
+mvn formatter:validate
+```

--- a/api/src/main/java/io/kroxylicious/testing/kafka/api/KafkaCluster.java
+++ b/api/src/main/java/io/kroxylicious/testing/kafka/api/KafkaCluster.java
@@ -29,7 +29,7 @@ public interface KafkaCluster extends AutoCloseable {
     void close() throws Exception;
 
     /**
-     *Returns the size of the cluster.
+     * @return the size of the cluster.
      */
     int getNumOfBrokers();
 

--- a/api/src/main/java/io/kroxylicious/testing/kafka/api/KafkaCluster.java
+++ b/api/src/main/java/io/kroxylicious/testing/kafka/api/KafkaCluster.java
@@ -29,6 +29,7 @@ public interface KafkaCluster extends AutoCloseable {
     void close() throws Exception;
 
     /**
+     * Gets the number of brokers expected in the cluster
      * @return the size of the cluster.
      */
     int getNumOfBrokers();
@@ -40,6 +41,7 @@ public interface KafkaCluster extends AutoCloseable {
     String getBootstrapServers();
 
     /**
+     * Gets the cluster id
      * @return The cluster id for KRaft-based clusters, otherwise null;
      */
     String getClusterId();

--- a/api/src/main/java/io/kroxylicious/testing/kafka/api/KafkaCluster.java
+++ b/api/src/main/java/io/kroxylicious/testing/kafka/api/KafkaCluster.java
@@ -29,6 +29,11 @@ public interface KafkaCluster extends AutoCloseable {
     void close() throws Exception;
 
     /**
+     * @return the size of the cluster
+     */
+    int getNumOfBrokers();
+
+    /**
      * Gets the bootstrap servers for this cluster
      * @return bootstrap servers
      */

--- a/api/src/main/java/io/kroxylicious/testing/kafka/api/KafkaCluster.java
+++ b/api/src/main/java/io/kroxylicious/testing/kafka/api/KafkaCluster.java
@@ -29,7 +29,7 @@ public interface KafkaCluster extends AutoCloseable {
     void close() throws Exception;
 
     /**
-     * @return the size of the cluster
+     *Returns the size of the cluster.
      */
     int getNumOfBrokers();
 

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
@@ -222,6 +222,11 @@ public class InVMKafkaCluster implements KafkaCluster {
         }
     }
 
+    @Override
+    public int getNumOfBrokers() {
+        return clusterConfig.getBrokersNum();
+    }
+
     private void releaseAllPorts() {
         releasePorts(controllerPorts);
         releasePorts(interBrokerPorts);

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
@@ -274,6 +274,11 @@ public class TestcontainersKafkaCluster implements Startable, KafkaCluster {
     }
 
     @Override
+    public int getNumOfBrokers() {
+        return clusterConfig.getBrokersNum();
+    }
+
+    @Override
     public void stop() {
         allContainers().parallel().forEach(GenericContainer::stop);
     }

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/InstanceFieldExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/InstanceFieldExtensionTest.java
@@ -30,7 +30,7 @@ public class InstanceFieldExtensionTest extends AbstractExtensionTest {
         var dc = describeCluster(instanceCluster.getKafkaClientConfiguration());
         assertEquals(1, dc.nodes().get().size());
         assertEquals(instanceCluster.getClusterId(), dc.clusterId().get());
-        var cbc = assertInstanceOf(InVMKafkaCluster.class, instanceCluster);
+        assertInstanceOf(InVMKafkaCluster.class, instanceCluster);
     }
 
     @Test

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/TemplateTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/TemplateTest.java
@@ -6,10 +6,8 @@
 package io.kroxylicious.testing.kafka.junit5ext;
 
 import java.lang.annotation.Annotation;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Stream;
@@ -48,46 +46,20 @@ public class TemplateTest {
                 brokerCluster(3));
     }
 
-    static Map<Integer, Integer> observedMultipleClusterSizes = new HashMap<>();
-
-    @Nested
-    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-    public class MultipleClusterSizes {
-        @TestTemplate
-        public void testMultipleClusterSizes(
-                                             @DimensionMethodSource(value = "clusterSizes", clazz = TemplateTest.class) KafkaCluster cluster)
-                throws ExecutionException, InterruptedException {
-            try (var admin = Admin.create(cluster.getKafkaClientConfiguration())) {
-                observedMultipleClusterSizes.compute(admin.describeCluster().nodes().get().size(),
-                        (k, v) -> v == null ? 1 : v + 1);
-            }
-        }
-
-        @AfterAll
-        public void afterAll() {
-            assertEquals(Map.of(1, 1, 3, 1),
-                    observedMultipleClusterSizes);
+    @TestTemplate
+    public void testMultipleClusterSizes(
+                                         @DimensionMethodSource(value = "clusterSizes", clazz = TemplateTest.class) KafkaCluster cluster)
+            throws ExecutionException, InterruptedException {
+        try (var admin = Admin.create(cluster.getKafkaClientConfiguration())) {
+            assertEquals(admin.describeCluster().nodes().get().size(), cluster.getNumOfBrokers());
         }
     }
 
-    static Map<Integer, Integer> observedMultipleClusterSizesWithAdminParameters = new HashMap<>();
-
-    @Nested
-    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-    public class MultipleClusterSizesWithAdminParameters {
-        @TestTemplate
-        public void testMultipleClusterSizesWithAdminParameters(@DimensionMethodSource(value = "clusterSizes", clazz = TemplateTest.class) KafkaCluster cluster,
-                                                                Admin admin)
-                throws ExecutionException, InterruptedException {
-            observedMultipleClusterSizesWithAdminParameters.compute(admin.describeCluster().nodes().get().size(),
-                    (k, v) -> v == null ? 1 : v + 1);
-        }
-
-        @AfterAll
-        public void afterAll() {
-            assertEquals(Map.of(1, 1, 3, 1),
-                    observedMultipleClusterSizesWithAdminParameters);
-        }
+    @TestTemplate
+    public void testMultipleClusterSizesWithAdminParameters(@DimensionMethodSource(value = "clusterSizes", clazz = TemplateTest.class) KafkaCluster cluster,
+                                                            Admin admin)
+            throws ExecutionException, InterruptedException {
+        assertEquals(admin.describeCluster().nodes().get().size(), cluster.getNumOfBrokers());
     }
 
     static Stream<BrokerConfig> compression() {
@@ -188,8 +160,7 @@ public class TemplateTest {
     public class Versions {
 
         @TestTemplate
-        public void testVersions(@DimensionMethodSource(value = "versions", clazz = TemplateTest.class) @KRaftCluster TestcontainersKafkaCluster cluster)
-                throws Exception {
+        public void testVersions(@DimensionMethodSource(value = "versions", clazz = TemplateTest.class) @KRaftCluster TestcontainersKafkaCluster cluster) {
             observedVersions.add(cluster.getKafkaVersion());
         }
 


### PR DESCRIPTION
- Added the getNumOfBrokers method into the KafkaCluster interface that close #56
- Refactor some tests that make use of the new method
- Added new readme section to validate the format of the files