### PR TITLE
Only make one PR after release

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -76,21 +76,17 @@ git push --tags
 echo "Deploying release to maven central"
 mvn deploy -Prelease -DskipTests=true -DreleaseSigningKey="${GPG_KEY}"
 
+git checkout -b "prepare-development-${RELEASE_DATE}" "prepare-release-${RELEASE_VERSION}-${RELEASE_DATE}"
+mvn versions:set -DnextSnapshot=true -DnextSnapshotIndexToIncrement="${SNAPSHOT_INCREMENT_INDEX}" -DgenerateBackupPoms=false
+
+git add '**/pom.xml' 'pom.xml'
+git commit --message "Start next development version" --signoff
+
 if ! command -v gh &> /dev/null
 then
     echo "gh command could not be found. Please create a pull request by hand https://github.com/kroxylicious/kroxylicious/compare"
     exit
 fi
 
-BODY="Release version ${RELEASE_VERSION}"
-
-echo "Create pull request to merge the released version."
-gh pr create --base main --title "Kroxylicious junit extension Release v${RELEASE_VERSION} ${RELEASE_DATE}" --body "${BODY}"
-
-git checkout -b "prepare-development-${RELEASE_DATE}" "${REPOSITORY}/${BRANCH_FROM}"
-mvn versions:set -DnextSnapshot=true -DnextSnapshotIndexToIncrement="${SNAPSHOT_INCREMENT_INDEX}" -DgenerateBackupPoms=false
-
-git add '**/pom.xml' 'pom.xml'
-git commit --message "Start next development version" --signoff
-
+echo "Create pull request to merge the released version & update to new snapshot version for development"
 gh pr create --base main --title "Kroxylicious junit extension development version ${RELEASE_DATE}" --body "prepare for new development version"


### PR DESCRIPTION
Previously 2 commits would be made on different branches from main, and a PR created against main on GitHub. Merging either of those would cause a conflict in the other. Also, there's a specific order that those commits need to merged in, so having two pull requests increases the potential for human error.

The intention of this change is to make it so that there will only be one PR, with the two commits ordered as they should be.