### PR TITLE
Fix #84: allow brokers to be added to/removed from the cluster

### DIFF
--- a/api/src/main/java/io/kroxylicious/testing/kafka/api/KafkaCluster.java
+++ b/api/src/main/java/io/kroxylicious/testing/kafka/api/KafkaCluster.java
@@ -23,6 +23,25 @@ public interface KafkaCluster extends AutoCloseable {
     void start();
 
     /**
+     * adds a new broker to the cluster. Once this method returns the caller is guaranteed that the new broker will
+     * be incorporated into the cluster.  In kraft mode, the broker added will always from the role 'broker'.
+     *
+     * @return kafka <code>node.id</code> of the created broker.
+     */
+    int addBroker();
+
+    /**
+     * removes broker identified by the given <code>node.id</code> from the cluster.  Once this method returns the
+     * caller is guaranteed that the broker has stopped and is no longer part of the cluster.
+     * <p>
+     * in kraft mode, it is not permitted to remove a broker that is the controller mode.
+     *
+     * @throws UnsupportedOperationException the <code>node.id</code> identifies a kraft controller
+     * @throws IllegalArgumentException      the node identified by <code>node.id</code> does not exist.
+     */
+    void removeBroker(int nodeId) throws UnsupportedOperationException, IllegalArgumentException;
+
+    /**
      * stops the cluster.
      */
     @Override

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
@@ -21,7 +21,6 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
-import java.util.function.IntFunction;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -333,62 +332,6 @@ public class KafkaClusterConfig {
     }
 
     /**
-     * Build the bootstrap servers string for general client access.
-     *
-     * @param endPointConfig the end point config
-     * @param brokersNum number of brokers
-     * @return the client bootstrap servers
-     */
-    @NotNull
-    public String buildClientBootstrapServers(KafkaEndpoints endPointConfig, int brokersNum) {
-        return buildBootstrapServers(brokersNum, endPointConfig::getClientEndpoint);
-    }
-
-    /**
-     * Build the bootstrap servers string for connecting to the anonymous listeners.
-     * Generally expected to be used by the extension for validating cluster status.
-     *
-     * @param endPointConfig the end point config
-     * @return the anon bootstrap servers
-     */
-    @NotNull
-    public String buildAnonBootstrapServers(KafkaEndpoints endPointConfig) {
-        return buildBootstrapServers(getBrokersNum(), endPointConfig::getAnonEndpoint);
-    }
-
-    /**
-     Build the bootstrap servers string for connecting to the controller listeners.
-     *
-     * @param kafkaEndpoints the kafka endpoints
-     * @return the controller bootstrap servers
-     */
-    @NotNull
-    public String buildControllerBootstrapServers(KafkaEndpoints kafkaEndpoints) {
-        return buildBootstrapServers(getBrokersNum(), kafkaEndpoints::getControllerEndpoint);
-    }
-
-    /**
-     * Build the bootstrap servers string for connecting to the inter broker listeners.
-     *
-     * @param kafkaEndpoints the kafka endpoints
-     * @return the interbroker bootstrap servers
-     */
-    @NotNull
-    public String buildInterBrokerBootstrapServers(KafkaEndpoints kafkaEndpoints) {
-        return buildBootstrapServers(getBrokersNum(), kafkaEndpoints::getInterBrokerEndpoint);
-    }
-
-    /**
-     * Generates client connection config to connect to the anonymous listeners within the cluster. Thus bypassing all authentication mechanisms.
-     *
-     * @param kafkaEndpoints the kafka endpoints
-     * @return the anon connect config for cluster
-     */
-    public Map<String, Object> getAnonConnectConfigForCluster(KafkaEndpoints kafkaEndpoints) {
-        return getConnectConfigForCluster(buildAnonBootstrapServers(kafkaEndpoints), null, null, null, null);
-    }
-
-    /**
      * Generates client connection config to connect to the cluster via the supplied bootstrap address.
      *
      * @param bootstrapServers the bootstrap servers
@@ -517,13 +460,6 @@ public class KafkaClusterConfig {
      */
     public String clusterId() {
         return isKraftMode() ? kafkaKraftClusterId : null;
-    }
-
-    private String buildBootstrapServers(Integer numBrokers, IntFunction<KafkaEndpoints.EndpointPair> brokerEndpoint) {
-        return IntStream.range(0, numBrokers)
-                .mapToObj(brokerEndpoint)
-                .map(KafkaEndpoints.EndpointPair::connectAddress)
-                .collect(Collectors.joining(","));
     }
 
     /**
@@ -669,5 +605,6 @@ public class KafkaClusterConfig {
          * @return the anon endpoint
          */
         EndpointPair getAnonEndpoint(int brokerId);
+
     }
 }

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
@@ -231,7 +231,6 @@ public class KafkaClusterConfig {
         if (isKraftMode()) {
             putConfig(server, "node.id", Integer.toString(brokerNum)); // Required by Kafka 3.3 onwards.
 
-            var controllerEndpoint = kafkaEndpoints.getControllerEndpoint(brokerNum);
             var quorumVoters = IntStream.range(0, kraftControllers)
                     .mapToObj(controllerId -> String.format("%d@//%s", controllerId, kafkaEndpoints.getControllerEndpoint(controllerId).connectAddress()))
                     .collect(Collectors.joining(","));
@@ -240,6 +239,7 @@ public class KafkaClusterConfig {
             protocolMap.put("CONTROLLER", SecurityProtocol.PLAINTEXT.name());
 
             if (brokerNum == 0) {
+                var controllerEndpoint = kafkaEndpoints.getControllerEndpoint(brokerNum);
                 putConfig(server, "process.roles", "broker,controller");
 
                 listeners.put("CONTROLLER", controllerEndpoint.getBind().toString());
@@ -336,11 +336,12 @@ public class KafkaClusterConfig {
      * Build the bootstrap servers string for general client access.
      *
      * @param endPointConfig the end point config
+     * @param brokersNum number of brokers
      * @return the client bootstrap servers
      */
     @NotNull
-    public String buildClientBootstrapServers(KafkaEndpoints endPointConfig) {
-        return buildBootstrapServers(getBrokersNum(), endPointConfig::getClientEndpoint);
+    public String buildClientBootstrapServers(KafkaEndpoints endPointConfig, int brokersNum) {
+        return buildBootstrapServers(brokersNum, endPointConfig::getClientEndpoint);
     }
 
     /**

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/Utils.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/Utils.java
@@ -56,11 +56,11 @@ public class Utils {
      *
      * @param connectionConfig the connection config
      * @param fromNodeId nodeId being evacuated
-     * @param toNodeIs replacement nodeId
+     * @param toNodeId replacement nodeId
      * @param timeout the timeout
      * @param timeUnit the time unit
      */
-    public static void awaitReassignmentOfKafkaInternalTopicsIfNecessary(Map<String, Object> connectionConfig, int fromNodeId, int toNodeIs, int timeout,
+    public static void awaitReassignmentOfKafkaInternalTopicsIfNecessary(Map<String, Object> connectionConfig, int fromNodeId, int toNodeId, int timeout,
                                                                          TimeUnit timeUnit) {
         var kafkaInternalTopics = List.of(Topic.GROUP_METADATA_TOPIC_NAME, Topic.TRANSACTION_STATE_TOPIC_NAME, Topic.CLUSTER_METADATA_TOPIC_NAME);
 
@@ -69,7 +69,7 @@ public class Utils {
 
                 Map<String, TopicDescription> topicDescriptions = describeKnownTopics(kafkaInternalTopics, admin);
                 var movements = new HashMap<TopicPartition, Optional<NewPartitionReassignment>>();
-                var toNodeReassignment = Optional.of(new NewPartitionReassignment(List.of(toNodeIs)));
+                var toNodeReassignment = Optional.of(new NewPartitionReassignment(List.of(toNodeId)));
                 topicDescriptions.forEach((name, description) -> {
                     // find all partitions that don't have a replica on at least one other node.
                     var toMove = description.partitions().stream().filter(p -> p.replicas().stream().anyMatch(n -> n.id() == fromNodeId) && p.replicas().size() < 2)

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
@@ -190,7 +190,7 @@ public class InVMKafkaCluster implements KafkaCluster {
             }
 
             private EndpointPair buildEndpointPair(SortedMap<Integer, ServerSocket> portRange, int brokerId) {
-                var port = portRange.values().stream().toList().get(brokerId);
+                var port = portRange.get(brokerId);
                 return EndpointPair.builder().bind(new Endpoint("0.0.0.0", port.getLocalPort())).connect(new Endpoint("localhost", port.getLocalPort())).build();
             }
         };

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/KafkaClusterTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/KafkaClusterTest.java
@@ -33,7 +33,6 @@ import io.kroxylicious.testing.kafka.common.KafkaClusterConfig;
 import io.kroxylicious.testing.kafka.common.KafkaClusterFactory;
 import io.kroxylicious.testing.kafka.common.KeytoolCertificateGenerator;
 
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/KafkaClusterTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/KafkaClusterTest.java
@@ -77,7 +77,7 @@ public class KafkaClusterTest {
         try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
                 .testInfo(testInfo)
                 .brokersNum(brokersNum)
-                .kraftMode(true)
+                .kraftMode(false)
                 .build())) {
             cluster.start();
             assertThat(cluster.getNumOfBrokers()).isEqualTo(brokersNum);
@@ -99,7 +99,7 @@ public class KafkaClusterTest {
         try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
                 .testInfo(testInfo)
                 .brokersNum(brokersNum)
-                .kraftMode(true)
+                .kraftMode(false)
                 .build())) {
             cluster.start();
             assertThat(cluster.getNumOfBrokers()).isEqualTo(brokersNum);
@@ -160,6 +160,27 @@ public class KafkaClusterTest {
             assertThat(cluster.getNumOfBrokers()).isEqualTo(brokersNum + 1);
             assertThat(cluster.getBootstrapServers().split(",")).hasSize(brokersNum + 1);
             verifyRecordRoundTrip(brokersNum + 1, cluster);
+        }
+    }
+
+    @Test
+    public void kafkaClusterKraftRemoveBroker() throws Exception {
+        int brokersNum = 3;
+        try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
+                .testInfo(testInfo)
+                .brokersNum(brokersNum)
+                .kraftMode(true)
+                .build())) {
+            cluster.start();
+            assertThat(cluster.getNumOfBrokers()).isEqualTo(brokersNum);
+            assertThat(cluster.getBootstrapServers().split(",")).hasSize(brokersNum);
+            verifyRecordRoundTrip(brokersNum, cluster);
+
+            cluster.removeBroker(1);
+
+            assertThat(cluster.getNumOfBrokers()).isEqualTo(brokersNum - 1);
+            assertThat(cluster.getBootstrapServers().split(",")).hasSize(brokersNum - 1);
+            verifyRecordRoundTrip(brokersNum - 1, cluster);
         }
     }
 

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfigTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfigTest.java
@@ -30,133 +30,20 @@ class KafkaClusterConfigTest {
     }
 
     @Test
-    void shouldBuildClientBootstrapAddressForSingleBroker() {
+    void generateConfigForSpecificBroker() {
         // Given
         kafkaClusterConfigBuilder.brokersNum(1);
-        final KafkaClusterConfig kafkaClusterConfig = kafkaClusterConfigBuilder.build();
+        var kafkaClusterConfig = kafkaClusterConfigBuilder.build();
 
         // When
-        final String clientBootstrapServers = kafkaClusterConfig.buildClientBootstrapServers(endpointConfig, kafkaClusterConfig.getBrokersNum());
+        final var config = kafkaClusterConfig.generateConfigForSpecificBroker(endpointConfig, 0);
 
         // Then
-        assertThat(clientBootstrapServers).doesNotContain(",");
-        assertThat(clientBootstrapServers).doesNotContain("//");
-        assertThat(clientBootstrapServers).contains("localhost:9092");
-    }
-
-    @Test
-    void shouldBuildClientBootstrapAddressForCluster() {
-        // Given
-        kafkaClusterConfigBuilder.brokersNum(3);
-        final KafkaClusterConfig kafkaClusterConfig = kafkaClusterConfigBuilder.build();
-
-        // When
-        final String clientBootstrapServers = kafkaClusterConfig.buildClientBootstrapServers(endpointConfig, kafkaClusterConfig.getBrokersNum());
-
-        // Then
-        assertThat(clientBootstrapServers).contains(",");
-        assertThat(clientBootstrapServers).doesNotContain("//");
-        assertThat(clientBootstrapServers).contains("localhost:9092");
-        assertThat(clientBootstrapServers).contains("localhost:9093");
-        assertThat(clientBootstrapServers).contains("localhost:9094");
-    }
-
-    @Test
-    void shouldBuildInterBrokerBootstrapAddressForSingleBroker() {
-        // Given
-        kafkaClusterConfigBuilder.brokersNum(1);
-        final KafkaClusterConfig kafkaClusterConfig = kafkaClusterConfigBuilder.build();
-
-        // When
-        final String interBrokerBootstrapServers = kafkaClusterConfig.buildInterBrokerBootstrapServers(endpointConfig);
-
-        // Then
-        assertThat(interBrokerBootstrapServers).doesNotContain(",");
-        assertThat(interBrokerBootstrapServers).doesNotContain("//");
-        assertThat(interBrokerBootstrapServers).contains("localhost:11092");
-    }
-
-    @Test
-    void shouldBuildInterBrokerBootstrapAddressForCluster() {
-        // Given
-        kafkaClusterConfigBuilder.brokersNum(3);
-        final KafkaClusterConfig kafkaClusterConfig = kafkaClusterConfigBuilder.build();
-
-        // When
-        final String interBrokerBootstrapServers = kafkaClusterConfig.buildInterBrokerBootstrapServers(endpointConfig);
-
-        // Then
-        assertThat(interBrokerBootstrapServers).contains(",");
-        assertThat(interBrokerBootstrapServers).doesNotContain("//");
-        assertThat(interBrokerBootstrapServers).contains("localhost:11092");
-        assertThat(interBrokerBootstrapServers).contains("localhost:11093");
-        assertThat(interBrokerBootstrapServers).contains("localhost:11094");
-    }
-
-    @Test
-    void shouldBuildControllerBootstrapAddressForSingleBroker() {
-        // Given
-        kafkaClusterConfigBuilder.brokersNum(1);
-        final KafkaClusterConfig kafkaClusterConfig = kafkaClusterConfigBuilder.build();
-
-        // When
-        final String controllerBootstrapServers = kafkaClusterConfig.buildControllerBootstrapServers(endpointConfig);
-
-        // Then
-        assertThat(controllerBootstrapServers).doesNotContain(",");
-        assertThat(controllerBootstrapServers).doesNotContain("//");
-        assertThat(controllerBootstrapServers).contains("localhost:10092");
-    }
-
-    @Test
-    void shouldBuildControllerBootstrapAddressForCluster() {
-        // Given
-
-        kafkaClusterConfigBuilder.brokersNum(3);
-        final KafkaClusterConfig kafkaClusterConfig = kafkaClusterConfigBuilder.build();
-
-        // When
-        final String controllerBootstrapServers = kafkaClusterConfig.buildControllerBootstrapServers(endpointConfig);
-
-        // Then
-        assertThat(controllerBootstrapServers).contains(",");
-        assertThat(controllerBootstrapServers).doesNotContain("//");
-        assertThat(controllerBootstrapServers).contains("localhost:10092");
-        assertThat(controllerBootstrapServers).contains("localhost:10093");
-        assertThat(controllerBootstrapServers).contains("localhost:10094");
-    }
-
-    @Test
-    void shouldBuildAnonBootstrapAddressForSingleBroker() {
-        // Given
-        kafkaClusterConfigBuilder.brokersNum(1);
-        final KafkaClusterConfig kafkaClusterConfig = kafkaClusterConfigBuilder.build();
-
-        // When
-        final String anonBootstrapServers = kafkaClusterConfig.buildAnonBootstrapServers(endpointConfig);
-
-        // Then
-        assertThat(anonBootstrapServers).doesNotContain(",");
-        assertThat(anonBootstrapServers).doesNotContain("//");
-        assertThat(anonBootstrapServers).contains("localhost:12092");
-    }
-
-    @Test
-    void shouldBuildAnonBootstrapAddressForCluster() {
-        // Given
-
-        kafkaClusterConfigBuilder.brokersNum(3);
-        final KafkaClusterConfig kafkaClusterConfig = kafkaClusterConfigBuilder.build();
-
-        // When
-        final String anonBootstrapServers = kafkaClusterConfig.buildAnonBootstrapServers(endpointConfig);
-
-        // Then
-        assertThat(anonBootstrapServers).contains(",");
-        assertThat(anonBootstrapServers).doesNotContain("//");
-        assertThat(anonBootstrapServers).contains("localhost:12092");
-        assertThat(anonBootstrapServers).contains("localhost:12093");
-        assertThat(anonBootstrapServers).contains("localhost:12094");
+        assertThat(config.getBrokerNum()).isEqualTo(0);
+        assertThat(config.getAnonPort()).isEqualTo(ANON_BASE_PORT);
+        assertThat(config.getExternalPort()).isEqualTo(CLIENT_BASE_PORT);
+        assertThat(config.getEndpoint()).isEqualTo("localhost:" + CLIENT_BASE_PORT);
+        assertThat(config.getProperties()).containsEntry("node.id", "0");
     }
 
     static class EndpointConfig implements KafkaClusterConfig.KafkaEndpoints {

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfigTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfigTest.java
@@ -36,7 +36,7 @@ class KafkaClusterConfigTest {
         final KafkaClusterConfig kafkaClusterConfig = kafkaClusterConfigBuilder.build();
 
         // When
-        final String clientBootstrapServers = kafkaClusterConfig.buildClientBootstrapServers(endpointConfig);
+        final String clientBootstrapServers = kafkaClusterConfig.buildClientBootstrapServers(endpointConfig, kafkaClusterConfig.getBrokersNum());
 
         // Then
         assertThat(clientBootstrapServers).doesNotContain(",");
@@ -51,7 +51,7 @@ class KafkaClusterConfigTest {
         final KafkaClusterConfig kafkaClusterConfig = kafkaClusterConfigBuilder.build();
 
         // When
-        final String clientBootstrapServers = kafkaClusterConfig.buildClientBootstrapServers(endpointConfig);
+        final String clientBootstrapServers = kafkaClusterConfig.buildClientBootstrapServers(endpointConfig, kafkaClusterConfig.getBrokersNum());
 
         // Then
         assertThat(clientBootstrapServers).contains(",");


### PR DESCRIPTION
Extends the `KafkaCluster` API to introduce the following functionality:

* `addBroker`
* `removeBroker`

The methods are blocking so won't return until the broker is added or removed.  I decided my original idea of returning Futures didn't really fit in the existing API or fit well with likely use-cases (the test would probably just block until the Future completed).
