### PR TITLE
Upgrade to kafka-clients 3.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Please enumerate all user-facing changes using format `<githib issue/pr number>:
 
 ## 0.4.0
 
+* [#127](https://github.com/kroxylicious/kroxylicious-junit5-extension/pull/127): Upgrade to kafka-clients 3.5.0
 * [#122](https://github.com/kroxylicious/kroxylicious-junit5-extension/pull/122): Bump maven-failsafe-plugin from 3.1.0 to 3.1.2
 * [#114](https://github.com/kroxylicious/kroxylicious-junit5-extension/issues/114): Fix defect that allowed the consistencyTest topic to be visible to users of the extension. 
 * [#116](https://github.com/kroxylicious/kroxylicious-junit5-extension/pull/116): Bump lombok from 1.18.26 to 1.18.28

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
@@ -89,7 +89,7 @@ public class InVMKafkaCluster implements KafkaCluster, KafkaClusterConfig.KafkaE
             ensureDirectoriesAreEmpty(directories);
             var metaProperties = StorageTool.buildMetadataProperties(clusterId, config);
             StorageTool.formatCommand(System.out, directories, metaProperties, MINIMUM_BOOTSTRAP_VERSION, true);
-            return new KafkaRaftServer(config, Time.SYSTEM, threadNamePrefix);
+            return new KafkaRaftServer(config, Time.SYSTEM);
         }
         else {
             return new KafkaServer(config, Time.SYSTEM, threadNamePrefix, false);

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
@@ -9,12 +9,17 @@ package io.kroxylicious.testing.kafka.invm;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
 import java.net.InetSocketAddress;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -89,11 +94,47 @@ public class InVMKafkaCluster implements KafkaCluster, KafkaClusterConfig.KafkaE
             ensureDirectoriesAreEmpty(directories);
             var metaProperties = StorageTool.buildMetadataProperties(clusterId, config);
             StorageTool.formatCommand(System.out, directories, metaProperties, MINIMUM_BOOTSTRAP_VERSION, true);
-            return new KafkaRaftServer(config, Time.SYSTEM);
+            return instantiateKraftServer(config, threadNamePrefix);
         }
         else {
             return new KafkaServer(config, Time.SYSTEM, threadNamePrefix, false);
         }
+    }
+
+    /**
+     * We instantiate the KafkaRaftServer reflectively to support running against versions of kafka
+     * older than 3.5.0. This is to enable users to downgrade the broker used for embedded testing rather
+     * than forcing them to increase their kafka-clients version to 3.5.0 (broker 3.5.0 requires kafka-clients 3.5.0)
+     */
+    @NotNull
+    private Server instantiateKraftServer(KafkaConfig config, Option<String> threadNamePrefix) {
+        Object kraftServer = construct(KafkaRaftServer.class, config, Time.SYSTEM)
+                .orElseGet(() -> construct(KafkaRaftServer.class, config, Time.SYSTEM, threadNamePrefix).orElseThrow());
+        return (Server) kraftServer;
+    }
+
+    public Optional<Object> construct(Class<?> clazz, Object... parameters) {
+        Constructor<?>[] declaredConstructors = clazz.getDeclaredConstructors();
+        return Arrays.stream(declaredConstructors)
+                .filter(constructor -> Modifier.isPublic(constructor.getModifiers()))
+                .filter(constructor -> {
+                    if (constructor.getParameterCount() != parameters.length) {
+                        return false;
+                    }
+                    boolean allMatch = true;
+                    Class<?>[] parameterTypes = constructor.getParameterTypes();
+                    for (int i = 0; i < parameters.length; i++) {
+                        allMatch = allMatch && parameterTypes[i].isInstance(parameters[i]);
+                    }
+                    return allMatch;
+                }).findFirst().map(constructor -> {
+                    try {
+                        return constructor.newInstance(parameters);
+                    }
+                    catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
     }
 
     @SuppressWarnings("ResultOfMethodCallIgnored")

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <skipUTs>${skipTests}</skipUTs>
 
         <junit.version>5.9.3</junit.version>
-        <kafka.version>3.4.1</kafka.version>
+        <kafka.version>3.5.0</kafka.version>
         <testcontainers.version>1.18.3</testcontainers.version>
         <lombok.version>1.18.28</lombok.version>
         <assertj-core.version>3.24.2</assertj-core.version>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Upgrade to kafka-clients 3.5.0

### Additional Context

kafka-clients 3.5.0 has some breaking changes so when we upgraded
it in kroxylicious the embedded kafka broker couldn't start. The
3.4.0 broker code is attempting to call methods removed in
kafka-clients 3.5.0

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
