### PR TITLE
Small KeytoolCertificateGenerator improvements 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please enumerate all user-facing changes using format `<githib issue/pr number>:
 
 ## 1.0.0
 
+## 0.5.0
+
+* [#130](https://github.com/kroxylicious/kroxylicious-junit5-extension/pull/130): Small KeytoolCertificateGenerator improvements (eliminates use of openssl)
+
 ## 0.4.0
 
 * [#127](https://github.com/kroxylicious/kroxylicious-junit5-extension/pull/127): Upgrade to kafka-clients 3.5.0

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -112,6 +112,10 @@
             <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>annotations</artifactId>
+        </dependency>
     </dependencies>
 
     

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
@@ -311,6 +311,7 @@ public class KafkaClusterConfig {
                     brokerKeytoolCertificateGenerator.generateTrustStore(clientKeytoolCertificateGenerator.getCertFilePath(), clientEndpoint.getConnect().getHost());
                     server.put(SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG, brokerKeytoolCertificateGenerator.getTrustStoreLocation());
                     server.put(SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG, brokerKeytoolCertificateGenerator.getPassword());
+                    server.put(SslConfigs.SSL_TRUSTSTORE_TYPE_CONFIG, brokerKeytoolCertificateGenerator.getTrustStoreType());
                 }
             }
             catch (GeneralSecurityException | IOException e) {
@@ -320,6 +321,8 @@ public class KafkaClusterConfig {
             server.put(SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG, brokerKeytoolCertificateGenerator.getKeyStoreLocation());
             server.put(SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG, brokerKeytoolCertificateGenerator.getPassword());
             server.put(SslConfigs.SSL_KEY_PASSWORD_CONFIG, brokerKeytoolCertificateGenerator.getPassword());
+            server.put(SslConfigs.SSL_KEYSTORE_TYPE_CONFIG, brokerKeytoolCertificateGenerator.getKeyStoreType());
+
         }
 
         putConfig(server, "offsets.topic.replication.factor", ONE_CONFIG);

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/common/KeytoolCertificateGeneratorTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/common/KeytoolCertificateGeneratorTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.testing.kafka.common;
+
+import java.io.File;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KeytoolCertificateGeneratorTest {
+    @Test
+    public void generatesKeyStore() throws Exception {
+        var generator = new KeytoolCertificateGenerator();
+        generator.generateSelfSignedCertificateEntry("test@kroxylicious.io", "localhost", "Dev",
+                "Kroxylicious.io", null, null, "US");
+
+        var keystore = generator.getKeyStoreLocation();
+        assertThat(keystore).isNotEmpty();
+        var keystoreFile = new File(keystore);
+        assertThat(keystoreFile).exists();
+        var password = generator.getPassword();
+
+        var ks = KeyStore.getInstance(keystoreFile, password.toCharArray());
+        var aliases = aliasList(ks);
+        assertThat(aliases).hasSize(1);
+        var alias = aliases.get(0);
+        assertThat(ks.getCertificate(alias)).isNotNull();
+        assertThat(ks.getKey(alias, password.toCharArray())).isNotNull();
+        assertThat(ks.getType()).isEqualTo(generator.getKeyStoreType());
+    }
+
+    @Test
+    public void generatesTrustStore() throws Exception {
+        var generator = new KeytoolCertificateGenerator();
+        generator.generateSelfSignedCertificateEntry("test@kroxylicious.io", "localhost", "Dev",
+                "Kroxylicious.io", null, null, "US");
+
+        var myAlias = "alias";
+        // Weird API
+        generator.generateTrustStore(generator.getCertFilePath(), myAlias);
+
+        var trustStore = generator.getTrustStoreLocation();
+        assertThat(trustStore).isNotEmpty();
+        var trustStoreFile = new File(trustStore);
+        assertThat(trustStoreFile).exists();
+        var password = generator.getPassword();
+
+        var ts = KeyStore.getInstance(trustStoreFile, password.toCharArray());
+        var aliases = aliasList(ts);
+        assertThat(aliases).hasSize(1);
+        var alias = aliases.get(0);
+        assertThat(alias).isEqualTo(myAlias);
+        assertThat(ts.getCertificate(alias)).isNotNull();
+        assertThat(ts.getType()).isEqualTo(generator.getTrustStoreType());
+    }
+
+    @NotNull
+    private List<String> aliasList(KeyStore ks) throws KeyStoreException {
+        List<String> aliases = new ArrayList<>();
+        ks.aliases().asIterator().forEachRemaining(alias -> aliases.add(alias));
+        return aliases;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
         <testcontainers.version>1.18.3</testcontainers.version>
         <lombok.version>1.18.28</lombok.version>
         <assertj-core.version>3.24.2</assertj-core.version>
+        <findbugs.annotations.version>3.0.1</findbugs.annotations.version>
         <zookeeper.version>3.8.1</zookeeper.version>
         <log4j.version>2.20.0</log4j.version>
         <awaitility.version>4.2.0</awaitility.version>
@@ -194,6 +195,12 @@
                 <groupId>org.rnorth.duct-tape</groupId>
                 <artifactId>duct-tape</artifactId>
                 <version>${duct-tape.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>annotations</artifactId>
+                <version>${findbugs.annotations.version}</version>
+                <scope>provided</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
### Type of change


- Refactoring

### Description

* remove several misleading references to `JKS` in the implementation.  The implementation always emitted `PKCS12` format key-stores - the references to `JKS` were actually ineffective.
* announce the keystore type in the kafka broker/client config.  Kafka assumes `JKS`. We were feeding it `PKCS12` which it was somehow accepting.  This change brings consistency.
* eliminate the use of `openssl`.  The implementation still shells-out to keytool, but at least this is one less dependency.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
