### PR TITLE
Support @BeforeEach and test cases referring to same cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ Please enumerate all user-facing changes using format `<githib issue/pr number>:
 
 ## 0.5.0
 
+* [#134](https://github.com/kroxylicious/kroxylicious-junit5-extension/pull/134): Support @BeforeEach and test cases referring to same cluster
 * [#130](https://github.com/kroxylicious/kroxylicious-junit5-extension/pull/130): Small KeytoolCertificateGenerator improvements (eliminates use of openssl)
+
+### Changes, deprecations and removals
+
+* It is now legal to declare multiple KafkaCluster parameters with the same explicit name, as long as later declarations only supply an @Name annotation and no constraint annotations. This will inject a reference to the existing cluster.
 
 ## 0.4.0
 

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KeytoolCertificateGenerator.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KeytoolCertificateGenerator.java
@@ -5,8 +5,6 @@
  */
 package io.kroxylicious.testing.kafka.common;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -22,6 +20,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import static java.lang.System.Logger.Level.DEBUG;
 import static java.lang.System.Logger.Level.WARNING;

--- a/integration-test/src/test/java/io/kroxylicious/testing/kafka/junit5ext/ExceptionalTest.java
+++ b/integration-test/src/test/java/io/kroxylicious/testing/kafka/junit5ext/ExceptionalTest.java
@@ -95,22 +95,22 @@ public class ExceptionalTest {
     }
 
     @ExtendWith(KafkaClusterExtension.class)
-    static class DuplicateNameCase {
-        // throw if two clusters declared with same cluster id
+    static class RedeclareConfigurationForExistingClusterCase {
+        // throw if two clusters declared with same cluster id but different constraints
         @Test
-        public void duplicateName(
-                                  @BrokerCluster(numBrokers = 1) @Name("A") KafkaCluster cluster1,
-                                  @BrokerCluster(numBrokers = 2) @Name("A") KafkaCluster cluster2) {
+        public void declareConfigurationForClusterATwice(
+                                                         @BrokerCluster(numBrokers = 1) @Name("A") KafkaCluster cluster1,
+                                                         @BrokerCluster(numBrokers = 2) @Name("A") KafkaCluster cluster2) {
             fail("Test execution shouldn't get this far");
         }
     }
 
     @Test
-    void verifyDuplicateName() {
-        String methodName = "duplicateName";
+    void verifyClusterReconfigurationName() {
+        String methodName = "declareConfigurationForClusterATwice";
 
         Events impossibleConstraint = engine("junit-jupiter")
-                .selectors(DiscoverySelectors.selectClass(DuplicateNameCase.class))
+                .selectors(DiscoverySelectors.selectClass(RedeclareConfigurationForExistingClusterCase.class))
                 .execute()
                 .allEvents();
         impossibleConstraint.assertStatistics(s -> s.failed(1));
@@ -121,9 +121,9 @@ public class ExceptionalTest {
                                         instanceOf(ParameterResolutionException.class),
                                         message("Failed to resolve parameter " +
                                                 "[io.kroxylicious.testing.kafka.api.KafkaCluster cluster2] in method " +
-                                                "[public void io.kroxylicious.testing.kafka.junit5ext.ExceptionalTest$DuplicateNameCase.duplicateName(io.kroxylicious.testing.kafka.api.KafkaCluster,io.kroxylicious.testing.kafka.api.KafkaCluster)]: "
+                                                "[public void io.kroxylicious.testing.kafka.junit5ext.ExceptionalTest$RedeclareConfigurationForExistingClusterCase.declareConfigurationForClusterATwice(io.kroxylicious.testing.kafka.api.KafkaCluster,io.kroxylicious.testing.kafka.api.KafkaCluster)]: "
                                                 +
-                                                "A KafkaCluster-typed declaration with @Name(\"A\") is already in scope"))));
+                                                "A KafkaCluster-typed declaration with @Name(\"A\") already exists, we cannot apply new constraints"))));
     }
 
     @ExtendWith(KafkaClusterExtension.class)

--- a/junit5-extension/src/main/java/io/kroxylicious/testing/kafka/junit5ext/KafkaClusterExtension.java
+++ b/junit5-extension/src/main/java/io/kroxylicious/testing/kafka/junit5ext/KafkaClusterExtension.java
@@ -792,10 +792,10 @@ public class KafkaClusterExtension implements
         if (sourceElement.isAnnotationPresent(Name.class)
                 && !sourceElement.getAnnotation(Name.class).value().isEmpty()) {
             clusterName = sourceElement.getAnnotation(Name.class).value();
-            Object o = store.get(clusterName);
-            if (o != null) {
+            if (store.get(clusterName) != null && !constraints.isEmpty()) {
                 throw new ExtensionConfigurationException(
-                        "A " + KafkaCluster.class.getSimpleName() + "-typed declaration with @Name(\"" + clusterName + "\") is already in scope");
+                        "A " + KafkaCluster.class.getSimpleName() + "-typed declaration with @Name(\"" + clusterName
+                                + "\") already exists, we cannot apply new constraints");
             }
         }
         else {
@@ -820,7 +820,6 @@ public class KafkaClusterExtension implements
                 extensionContext.getUniqueId(),
                 sourceElement,
                 clusterName);
-        cluster.start();
         return cluster;
     }
 
@@ -953,6 +952,7 @@ public class KafkaClusterExtension implements
                 extensionContext.getUniqueId(),
                 sourceElement,
                 clusterName);
+        c.start();
         return new Closeable<>(sourceElement, clusterName, c);
     }
 

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/BeforeEachTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/BeforeEachTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.testing.kafka.junit5ext;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.admin.TopicListing;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.kroxylicious.testing.kafka.api.KafkaCluster;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(KafkaClusterExtension.class)
+public class BeforeEachTest {
+
+    @BeforeEach
+    public void setup(@Name("a") KafkaCluster cluster, @Name("a") Admin admin) throws Exception {
+        admin.createTopics(List.of(new NewTopic("topicName", 1, (short) 1))).all().get(10, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void test(@Name("a") KafkaCluster cluster, @Name("a") Admin admin) throws Exception {
+        Collection<TopicListing> topicListings = admin.listTopics().listings().get(10, TimeUnit.SECONDS);
+        assertEquals(1, topicListings.size());
+        assertEquals("topicName", topicListings.iterator().next().name());
+    }
+}

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/ParameterExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/ParameterExtensionTest.java
@@ -34,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
@@ -109,6 +110,19 @@ public class ParameterExtensionTest extends AbstractExtensionTest {
         assertSameCluster(clusterB, adminB);
         await().atMost(CLUSTER_FORMATION_TIMEOUT).untilAsserted(() -> assertEquals(2, describeCluster(clusterB.getKafkaClientConfiguration()).nodes().get().size()));
         assertEquals(2, describeCluster(adminB).nodes().get().size());
+    }
+
+    @Test
+    public void multipleReferencesToTheSameCluster(
+                                                   @BrokerCluster(numBrokers = 1) @Name("A") KafkaCluster clusterA,
+                                                   @Name("A") KafkaCluster clusterARef,
+                                                   @Name("A") Admin adminA)
+            throws ExecutionException, InterruptedException {
+        assertSameCluster(clusterA, adminA);
+        assertSameCluster(clusterARef, adminA);
+        assertEquals(1, describeCluster(clusterA.getKafkaClientConfiguration()).nodes().get().size());
+        assertEquals(1, describeCluster(adminA).nodes().get().size());
+        assertSame(clusterA, clusterARef);
     }
 
     // multiple clients connected to the same cluster (e.g. different users)


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Users can now refer to the same cluster from an `@BeforeEach` annotated method and the subsequent test method when using explicitly named clusters.

For example:

```java
@BeforeEach
public void setup(@Name("clusterA") KafkaCluster cluster) {
    .. do setup work ..
}

@Test
public void test(@Name("clusterA") KafkaCluster cluster) {
    .. do test work ..
}
```

Note that without the `@Name` annotations each parameter would have a unique cluster injected.

As a consequence it's now legal to have multiple references to the same cluster as long as later declarations only supply an `@Name` annotation and no constraint annotations (because re-declaring constraints for a cluster that already exists can't be done).

### legal example
```java
public void test(@BrokerCluster(numBrokers = 2) @Name("clusterA") KafkaCluster cluster, @Name("clusterA") KafkaCluster clusterRef) {
    .. do test work ..
}
```

### illegal examples
```java
public void test(@BrokerCluster(numBrokers = 2) @Name("clusterA") KafkaCluster cluster, @BrokerCluster(numBrokers = 1) @Name("clusterA") KafkaCluster clusterRef) {
    .. do test work ..
}
```

```java
// we disallow any constraints even if they're identical
public void test(@BrokerCluster(numBrokers = 2) @Name("clusterA") KafkaCluster cluster, @BrokerCluster(numBrokers = 2) @Name("clusterA") KafkaCluster clusterRef) {
    .. do test work ..
}
```

### Additional Context

Why:
We might want to extract some common setup to an `@BeforeEach` annotated method and have it refer to the same cluster as is used later in the test. For example to create some topics or assert some pre-conditions like cluster size for all cases.

Note this changes an existing behaviour where it was not allowed to have multiple KafkaClusters injected using the same name. This makes sense because a KafkaCluster declaration also implies the constraints required and the multiple declarations could have different constraints. So with the new change a parameter is allowed to refer to a cluster instantiated earlier, but not supply any constraints.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
