### PR TITLE
Fix #86: Add API to restart one or more kafka broker(s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Please enumerate all user-facing changes using format `<githib issue/pr number>:
 
 ## 0.5.0
 
+* [#86](https://github.com/kroxylicious/kroxylicious-junit5-extension/issues/86) Added API to restart one or more brokers of a kafka cluster.
 * [#142](https://github.com/kroxylicious/kroxylicious-junit5-extension/pull/142) Prevent spinning in Utils#createTopic.
 * [#140](https://github.com/kroxylicious/kroxylicious-junit5-extension/issues/140) Prevent docker networks accumulations during test runs.
 * [#134](https://github.com/kroxylicious/kroxylicious-junit5-extension/pull/134): Support @BeforeEach and test cases referring to same cluster

--- a/api/src/main/java/io/kroxylicious/testing/kafka/api/KafkaCluster.java
+++ b/api/src/main/java/io/kroxylicious/testing/kafka/api/KafkaCluster.java
@@ -7,12 +7,14 @@
 package io.kroxylicious.testing.kafka.api;
 
 import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * A KafkaCluster, from which is it possible to create/connect clients.
  * Clients can be created using {@link #getKafkaClientConfiguration()} or
  * {@link #getKafkaClientConfiguration(String, String)}.
- *
+ * <br/>
  * The cluster needs to be {@link #start() start}ed prior to use,
  * and should be {@link #close() close}d after use.
  */
@@ -33,14 +35,49 @@ public interface KafkaCluster extends AutoCloseable {
     /**
      * removes broker identified by the given <code>node.id</code> from the cluster.  Once this method returns the
      * caller is guaranteed that the broker has stopped and is no longer part of the cluster.
-     * <p>
-     * in kraft mode, it is not permitted to remove a broker that is the controller mode.
+     * <br/>
+     * It is not permitted to remove a broker from a cluster that has stopped brokers.
+     * <br/>
+     * In kraft mode, it is not permitted to remove a broker that is the controller mode.
      *
      * @param nodeId node to be removed from the cluster
      * @throws UnsupportedOperationException the <code>node.id</code> identifies a kraft controller
      * @throws IllegalArgumentException      the node identified by <code>node.id</code> does not exist.
+     * @throws IllegalStateException         the cluster has stopped brokers.
      */
-    void removeBroker(int nodeId) throws UnsupportedOperationException, IllegalArgumentException;
+    void removeBroker(int nodeId) throws UnsupportedOperationException, IllegalArgumentException, IllegalStateException;
+
+    /**
+     * Stops the nodes(s) identified by the supplied predicate.  Once this method returns the
+     * caller is guaranteed that the node(s) have been stopped.
+     * <br/>
+     * The caller specifies a <code>terminationStyle</code>.  If it is set {@link TerminationStyle#ABRUPT}, the kafka
+     * node(s) will be abruptly killed, rather than undergoing a graceful shutdown. This may be useful to test cases
+     * wishing to explore networking edge cases.  The implementation may ignore this parameter if the
+     * implementation is unable to support the requested style of termination. In this case, the implementation
+     * is free to use an alternative termination style instead.
+     * <br/>
+     * If a subset of nodes in the cluster are stopped, there's no guarantee that the cluster actually remains
+     * usable. It is the caller's responsibility to ensure that Kafka internal topics (such as <code>__consumer_offsets</code>)
+     * remain sufficiently replicated.  In the KRaft case, it is the caller's responsibility to ensure at least one
+     * controller remains.
+     * <br/>
+     * Stopping a node that is already stopped has no effect.
+     *
+     * @param nodeIdPredicate  predicate that returns true if the node identified by the given nodeId should be restarted
+     * @param terminationStyle the style of termination used to shut down the broker(s).
+     */
+    void stopNodes(Predicate<Integer> nodeIdPredicate, TerminationStyle terminationStyle);
+
+    /**
+     * Starts node(s) identified by the supplied predicate.  Use this method to restart node(s)
+     * previously stopped by {@link #stopNodes(Predicate, TerminationStyle)}.
+     * <br/>
+     * Starting a node that is already started has no effect.
+     *
+     * @param nodeIdPredicate  predicate that returns true if the node identified by the given nodeId should be restarted
+     */
+    void startNodes(Predicate<Integer> nodeIdPredicate);
 
     /**
      * stops the cluster.
@@ -49,10 +86,18 @@ public interface KafkaCluster extends AutoCloseable {
     void close() throws Exception;
 
     /**
-     * Gets the number of brokers expected in the cluster
+     * Gets the number of brokers in the cluster, including any that are stopped.
      * @return the size of the cluster.
      */
     int getNumOfBrokers();
+
+    /**
+     * Returns the set of node ids that correspond to the brokers that are currently stopped.  The set
+     * will be empty if no brokers are currently stopped.
+     *
+     * @return set of node ids.
+     */
+    Set<Integer> getStoppedBrokers();
 
     /**
      * Gets the bootstrap servers for this cluster

--- a/api/src/main/java/io/kroxylicious/testing/kafka/api/TerminationStyle.java
+++ b/api/src/main/java/io/kroxylicious/testing/kafka/api/TerminationStyle.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.testing.kafka.api;
+
+public enum TerminationStyle {
+    /**
+     * Graceful termination style where components are requested to terminate and have the opportunity to close
+     * resources (files, network connections etc.) that they are using before they exit.
+     */
+    GRACEFUL,
+
+    /**
+     * Abrupt termination style where components are killed immediately.
+     */
+    ABRUPT
+}

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
@@ -34,6 +34,7 @@ import org.apache.kafka.common.security.auth.SecurityProtocol;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.TestInfo;
 
+import kafka.server.KafkaConfig;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Singular;
@@ -267,6 +268,7 @@ public class KafkaClusterConfig {
             putConfig(server, "zookeeper.connect", kafkaEndpoints.getEndpointPair(Listener.CONTROLLER, 0).connectAddress());
             putConfig(server, "zookeeper.sasl.enabled", "false");
             putConfig(server, "zookeeper.connection.timeout.ms", Long.toString(60000));
+            putConfig(server, KafkaConfig.ZkSessionTimeoutMsProp(), Long.toString(6000));
         }
 
         putConfig(server, "listener.security.protocol.map",

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/Utils.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/Utils.java
@@ -30,6 +30,7 @@ import org.apache.kafka.common.TopicPartitionInfo;
 import org.apache.kafka.common.errors.InvalidReplicationFactorException;
 import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.common.errors.TopicDeletionDisabledException;
+import org.apache.kafka.common.errors.TopicExistsException;
 import org.apache.kafka.common.errors.UnknownTopicOrPartitionException;
 import org.apache.kafka.common.internals.Topic;
 import org.awaitility.Awaitility;
@@ -205,7 +206,8 @@ public class Utils {
                 .thenRun(() -> log.debug("Create future for topic {} completed.", CONSISTENCY_TEST))
                 .exceptionallyComposeAsync((throwable) -> {
                     log.warn("Failed to create topic: {} due to {}", CONSISTENCY_TEST, throwable.getMessage());
-                    if (throwable instanceof RetriableException || throwable instanceof InvalidReplicationFactorException) {
+                    if (throwable instanceof RetriableException || throwable instanceof InvalidReplicationFactorException
+                            || (throwable instanceof TopicExistsException && throwable.getMessage().contains("is marked for deletion"))) {
                         // Retry the creation of the topic. The delayed executor used in this stage's handling avoids
                         // a tight spinning loop.
                         return createTopic(expectedBrokerCount, admin);

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/Utils.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/Utils.java
@@ -212,11 +212,7 @@ public class Utils {
                 .thenRun(() -> log.debug("Create future for topic {} completed.", CONSISTENCY_TEST))
                 .exceptionallyComposeAsync((throwable) -> {
                     log.warn("Failed to create topic: {} due to {}", CONSISTENCY_TEST, throwable.getMessage());
-                    if (throwable instanceof CompletionException && throwable.getCause() != null) {
-                        throwable = throwable.getCause();
-                    }
-                    if (throwable instanceof RetriableException || throwable instanceof InvalidReplicationFactorException
-                            || (throwable instanceof TopicExistsException && throwable.getMessage().contains("is marked for deletion"))) {
+                    if (isRetriable(throwable)) {
                         // Retry the creation of the topic. The delayed executor used in this stage's handling avoids
                         // a tight spinning loop.
                         return createTopic(expectedBrokerCount, admin);
@@ -225,6 +221,14 @@ public class Utils {
                         return CompletableFuture.failedStage(new RuntimeException("Failed to create topic: " + CONSISTENCY_TEST, throwable));
                     }
                 }, CompletableFuture.delayedExecutor(100, TimeUnit.MILLISECONDS));
+    }
+
+    private static boolean isRetriable(Throwable potentiallyWrapped) {
+        // If the throwable originates from within a CompletionStage's handler, it will be wrapped within a
+        // CompletionException.
+        var throwable = potentiallyWrapped instanceof CompletionException && potentiallyWrapped.getCause() != null ? potentiallyWrapped.getCause() : potentiallyWrapped;
+        return throwable instanceof RetriableException || throwable instanceof InvalidReplicationFactorException
+                || (throwable instanceof TopicExistsException && throwable.getMessage().contains("is marked for deletion"));
     }
 
     /**

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/KafkaClusterTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/KafkaClusterTest.java
@@ -18,7 +18,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
-import io.kroxylicious.testing.kafka.common.Utils;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -45,6 +44,7 @@ import io.kroxylicious.testing.kafka.clients.CloseableProducer;
 import io.kroxylicious.testing.kafka.common.KafkaClusterConfig;
 import io.kroxylicious.testing.kafka.common.KafkaClusterFactory;
 import io.kroxylicious.testing.kafka.common.KeytoolCertificateGenerator;
+import io.kroxylicious.testing.kafka.common.Utils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/KafkaClusterTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/KafkaClusterTest.java
@@ -6,26 +6,39 @@
 package io.kroxylicious.testing.kafka;
 
 import java.io.IOException;
+import java.net.ConnectException;
+import java.net.Socket;
 import java.security.GeneralSecurityException;
 import java.time.Duration;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
 
+import io.kroxylicious.testing.kafka.common.Utils;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.Node;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import io.kroxylicious.testing.kafka.api.TerminationStyle;
 import io.kroxylicious.testing.kafka.clients.CloseableAdmin;
 import io.kroxylicious.testing.kafka.clients.CloseableConsumer;
 import io.kroxylicious.testing.kafka.clients.CloseableProducer;
@@ -36,6 +49,7 @@ import io.kroxylicious.testing.kafka.common.KeytoolCertificateGenerator;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * Test case that simply exercises the ability to control the kafka cluster from the test.
@@ -69,13 +83,14 @@ public class KafkaClusterTest {
         }
     }
 
-    @Test
-    public void kafkaClusterZookeeperAddBroker() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    public void kafkaClusterAddBroker(boolean kraft) throws Exception {
         int brokersNum = 1;
         try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
                 .testInfo(testInfo)
                 .brokersNum(brokersNum)
-                .kraftMode(false)
+                .kraftMode(kraft)
                 .build())) {
             cluster.start();
             assertThat(cluster.getNumOfBrokers()).isEqualTo(brokersNum);
@@ -91,24 +106,104 @@ public class KafkaClusterTest {
         }
     }
 
-    @Test
-    public void kafkaClusterZookeeperRemoveBroker() throws Exception {
-        int brokersNum = 2;
+    public static Stream<Arguments> stopAndStartBrokers() {
+        return Stream.of(
+                Arguments.of(1, true, TerminationStyle.ABRUPT, (Predicate<Integer>) node -> true),
+                Arguments.of(2, true, TerminationStyle.ABRUPT, (Predicate<Integer>) node -> node == 1),
+                Arguments.of(2, true, TerminationStyle.ABRUPT, (Predicate<Integer>) node -> true),
+                Arguments.of(1, true, TerminationStyle.GRACEFUL, (Predicate<Integer>) node -> true),
+                Arguments.of(1, false, TerminationStyle.ABRUPT, (Predicate<Integer>) node -> true));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    public void stopAndStartBrokers(int brokersNum, boolean kraft, TerminationStyle terminationStyle, Predicate<Integer> brokerPredicate) throws Exception {
         try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
                 .testInfo(testInfo)
                 .brokersNum(brokersNum)
-                .kraftMode(false)
+                .kraftMode(kraft)
                 .build())) {
             cluster.start();
             assertThat(cluster.getNumOfBrokers()).isEqualTo(brokersNum);
-            assertThat(cluster.getBootstrapServers().split(",")).hasSize(brokersNum);
             verifyRecordRoundTrip(brokersNum, cluster);
 
-            cluster.removeBroker(1);
+            var nodes = describeClusterNodes(cluster);
+            var brokersExpectedDown = nodes.stream().filter(n -> brokerPredicate.test(n.id())).toList();
 
-            assertThat(cluster.getNumOfBrokers()).isEqualTo(brokersNum - 1);
-            assertThat(cluster.getBootstrapServers().split(",")).hasSize(brokersNum - 1);
-            verifyRecordRoundTrip(brokersNum - 1, cluster);
+            assertThat(cluster.getStoppedBrokers()).hasSize(0);
+
+            cluster.stopNodes(brokerPredicate, terminationStyle);
+
+            assertThat(cluster.getNumOfBrokers()).isEqualTo(brokersNum);
+            assertThat(cluster.getStoppedBrokers()).hasSameSizeAs(brokersExpectedDown);
+            brokersExpectedDown.forEach(this::assertBrokerRefusesConnection);
+
+            cluster.startNodes(brokerPredicate);
+
+            assertThat(cluster.getNumOfBrokers()).isEqualTo(brokersNum);
+            assertThat(cluster.getStoppedBrokers()).hasSize(0);
+
+            // ensures that all brokers of the cluster are back in service.
+            verifyRecordRoundTrip(brokersNum, cluster);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    public void stopAndStartIdempotency(boolean kraft) throws Exception {
+        try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
+                .testInfo(testInfo)
+                .kraftMode(kraft)
+                .build())) {
+            cluster.start();
+            verifyRecordRoundTrip(cluster.getNumOfBrokers(), cluster);
+
+            assertThat(cluster.getStoppedBrokers()).hasSize(0);
+            // starting idempotent
+            cluster.startNodes((u) -> true);
+            assertThat(cluster.getStoppedBrokers()).hasSize(0);
+
+            cluster.stopNodes((u) -> true, null);
+            assertThat(cluster.getStoppedBrokers()).hasSize(1);
+
+            // stopping idempotent
+            cluster.stopNodes((u) -> true, null);
+            assertThat(cluster.getStoppedBrokers()).hasSize(1);
+
+            cluster.startNodes((u) -> true);
+            verifyRecordRoundTrip(cluster.getNumOfBrokers(), cluster);
+            assertThat(cluster.getStoppedBrokers()).hasSize(0);
+
+            // starting idempotent
+            cluster.startNodes((u) -> true);
+            assertThat(cluster.getStoppedBrokers()).hasSize(0);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    public void stopAndStartIncrementally(boolean kraft) throws Exception {
+        try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
+                .testInfo(testInfo)
+                .kraftMode(kraft)
+                .brokersNum(2)
+                .build())) {
+            cluster.start();
+            verifyRecordRoundTrip(cluster.getNumOfBrokers(), cluster);
+            assertThat(cluster.getStoppedBrokers()).hasSize(0);
+
+            cluster.stopNodes((n) -> n == 1, null);
+            assertThat(cluster.getStoppedBrokers()).containsExactlyInAnyOrder(1);
+
+            cluster.stopNodes((u) -> true, null);
+            assertThat(cluster.getStoppedBrokers()).containsExactlyInAnyOrder(0, 1);
+
+            cluster.startNodes((n) -> n == 1);
+            assertThat(cluster.getStoppedBrokers()).containsExactlyInAnyOrder(0);
+
+            cluster.startNodes((u) -> true);
+            assertThat(cluster.getStoppedBrokers()).hasSize(0);
+            verifyRecordRoundTrip(cluster.getNumOfBrokers(), cluster);
         }
     }
 
@@ -138,36 +233,14 @@ public class KafkaClusterTest {
         }
     }
 
-    @Test
-    public void kafkaClusterKraftAddBroker() throws Exception {
-        int brokersNum = 1;
-        try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
-                .testInfo(testInfo)
-                .brokersNum(brokersNum)
-                .kraftMode(true)
-                .build())) {
-            cluster.start();
-
-            assertThat(cluster.getNumOfBrokers()).isEqualTo(brokersNum);
-            assertThat(cluster.getBootstrapServers().split(",")).hasSize(brokersNum);
-            verifyRecordRoundTrip(brokersNum, cluster);
-
-            int nodeId = cluster.addBroker();
-            assertThat(nodeId).isEqualTo(1);
-
-            assertThat(cluster.getNumOfBrokers()).isEqualTo(brokersNum + 1);
-            assertThat(cluster.getBootstrapServers().split(",")).hasSize(brokersNum + 1);
-            verifyRecordRoundTrip(brokersNum + 1, cluster);
-        }
-    }
-
-    @Test
-    public void kafkaClusterKraftRemoveBroker() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    public void kafkaClusterRemoveBroker(boolean kraft) throws Exception {
         int brokersNum = 3;
         try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
                 .testInfo(testInfo)
                 .brokersNum(brokersNum)
-                .kraftMode(true)
+                .kraftMode(kraft)
                 .build())) {
             cluster.start();
             assertThat(cluster.getNumOfBrokers()).isEqualTo(brokersNum);
@@ -179,6 +252,25 @@ public class KafkaClusterTest {
             assertThat(cluster.getNumOfBrokers()).isEqualTo(brokersNum - 1);
             assertThat(cluster.getBootstrapServers().split(",")).hasSize(brokersNum - 1);
             verifyRecordRoundTrip(brokersNum - 1, cluster);
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = { true, false })
+    public void kafkaClusterRemoveWithStoppedBrokerDisallowed(boolean kraft) throws Exception {
+        int brokersNum = 2;
+        try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
+                .testInfo(testInfo)
+                .brokersNum(brokersNum)
+                .kraftMode(kraft)
+                .build())) {
+            cluster.start();
+
+            cluster.stopNodes(n -> n == 1, null);
+
+            // Node zero is the controller
+            assertThrows(IllegalStateException.class, () -> cluster.removeBroker(1),
+                    "Expect attempt to remove a node when the cluster has stopped brokers to be rejected");
         }
     }
 
@@ -391,11 +483,34 @@ public class KafkaClusterTest {
     }
 
     private void createTopic(Admin admin, String topic, short replicationFactor) throws Exception {
-        admin.createTopics(List.of(new NewTopic(topic, 1, replicationFactor))).all().get();
+        Utils.awaitCondition(60, TimeUnit.SECONDS).until(() -> {
+            admin.createTopics(List.of(new NewTopic(topic, 1, replicationFactor))).all().get();
+            return true;
+        });
     }
 
     private void deleteTopic(Admin admin, String topic) throws Exception {
         admin.deleteTopics(List.of(topic)).all().get();
+    }
+
+    private Collection<Node> describeClusterNodes(KafkaCluster cluster) {
+        try (var admin = CloseableAdmin.create(cluster.getKafkaClientConfiguration())) {
+            return Awaitility.waitAtMost(Duration.ofSeconds(10)).until(() -> admin.describeCluster().nodes().get(2, TimeUnit.SECONDS),
+                    n -> n.size() == cluster.getNumOfBrokers());
+        }
+    }
+
+    private void assertBrokerRefusesConnection(Node n) {
+        try (var ignored = new Socket(n.host(), n.port())) {
+            // If we get this far, the connection has been established, which is unexpected.
+            fail("unexpected successful connection open to broker " + n);
+        }
+        catch (ConnectException e) {
+            // pass - this is the expected "connection refused"
+        }
+        catch (Throwable e) {
+            fail("unexpected exception probing for broker " + n, e);
+        }
     }
 
     @BeforeEach

--- a/impl/src/test/resources/log4j2-test.properties
+++ b/impl/src/test/resources/log4j2-test.properties
@@ -37,3 +37,7 @@ logger.Kafka.additivity = false
 logger.Broker = off, STDOUT
 logger.Broker.name = kafka
 logger.Broker.additivity = false
+
+logger.Testcontainers = off, STDOUT
+logger.Testcontainers.name = org.testcontainers.containers
+logger.Testcontainers.additivity = false

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/ParameterExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/ParameterExtensionTest.java
@@ -28,6 +28,7 @@ import io.kroxylicious.testing.kafka.common.Tls;
 import io.kroxylicious.testing.kafka.common.ZooKeeperCluster;
 import io.kroxylicious.testing.kafka.invm.InVMKafkaCluster;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -37,7 +38,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
 @ExtendWith(KafkaClusterExtension.class)
 public class ParameterExtensionTest extends AbstractExtensionTest {


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

Add API to restart one or more kafka broker(s).

### Additional Context

This is done so that users of the test framework may exercise code paths where the broker(s) of the cluster are restarted, thus ensuring the robustness of error handling code etc.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
