### PR TITLE
Fix #140 - Prevent docker networks accumulations during test runs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Please enumerate all user-facing changes using format `<githib issue/pr number>:
 
 ## 0.5.0
 
+* [#140](https://github.com/kroxylicious/kroxylicious-junit5-extension/issues/140) Prevent docker networks accumulations during test runs.
 * [#134](https://github.com/kroxylicious/kroxylicious-junit5-extension/pull/134): Support @BeforeEach and test cases referring to same cluster
 * [#130](https://github.com/kroxylicious/kroxylicious-junit5-extension/pull/130): Small KeytoolCertificateGenerator improvements (eliminates use of openssl)
 

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
@@ -341,7 +341,12 @@ public class TestcontainersKafkaCluster implements Startable, KafkaCluster, Kafk
 
     @Override
     public synchronized void stop() {
-        allContainers().parallel().forEach(GenericContainer::stop);
+        try {
+            allContainers().parallel().forEach(GenericContainer::stop);
+        }
+        finally {
+            network.close();
+        }
     }
 
     @Override


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Docker networks were being leaked *during* the test runs, one network instance per test, when run in `TEST_CLUSTER_EXECUTION_MODE=CONTAINER` mode.  The change prevents the leaks by closing the instance scoped network on `KafkaCluster#close()`.

### Additional Context

This was noticed as I added more tests to the test suite.  All of the sudden, the test suite started to become unstable.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
