### PR TITLE
Fix regression caused by #142

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -50,3 +50,10 @@ jobs:
 
       - name: 'Run tests in containers'
         run: TEST_CLUSTER_EXECUTION_MODE=CONTAINER KAFKA_VERSION=latest mvn -B clean verify -Dsurefire.failIfNoSpecifiedTests=false -Dtest=KafkaClusterTest
+
+      - name: Archive container logs
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: container-logs
+          path: "**/container-logs/**/*.log"


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

 Fix regression introduced into Utils#createTopic by #142 3cd6816bfa71b0961e6eb7d4616af8d038c4b0be

* Regression meant that the create topic looping was broken.  Exceptions occurring during stage handlers are propagated to subsequent handlers wrapped by a `CompletionException`.  The code forgot to handle this case.
* Use `failFast` to short circuit awaitExpectedBrokerCountInClusterViaTopic if the createTopic fails unexpectedly.  This will reveal the error that caused `createTopic` to us
* Also enabled archiving of the container logs in the CI workflow, in the case of failure.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
