### PR TITLE
Direct storage formatting stdout to the log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Please enumerate all user-facing changes using format `<githib issue/pr number>:
 
 ## 0.5.0
 
+* [#145](https://github.com/kroxylicious/kroxylicious-junit5-extension/pull/145) Direct storage formatting stdout to the log
 * [#142](https://github.com/kroxylicious/kroxylicious-junit5-extension/pull/142) Prevent spinning in Utils#createTopic.
 * [#140](https://github.com/kroxylicious/kroxylicious-junit5-extension/issues/140) Prevent docker networks accumulations during test runs.
 * [#134](https://github.com/kroxylicious/kroxylicious-junit5-extension/pull/134): Support @BeforeEach and test cases referring to same cluster

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -116,6 +116,16 @@
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>annotations</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
@@ -8,6 +8,7 @@ package io.kroxylicious.testing.kafka.invm;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.io.UncheckedIOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -52,6 +53,7 @@ import static org.apache.kafka.server.common.MetadataVersion.MINIMUM_BOOTSTRAP_V
  */
 public class InVMKafkaCluster implements KafkaCluster, KafkaClusterConfig.KafkaEndpoints {
     private static final System.Logger LOGGER = System.getLogger(InVMKafkaCluster.class.getName());
+    private static final PrintStream LOGGING_PRINT_STREAM = LoggingPrintStream.loggingPrintStream(LOGGER, System.Logger.Level.DEBUG);
     private static final int STARTUP_TIMEOUT = 30;
 
     private final KafkaClusterConfig clusterConfig;
@@ -93,7 +95,7 @@ public class InVMKafkaCluster implements KafkaCluster, KafkaClusterConfig.KafkaE
             var directories = StorageTool.configToLogDirectories(config);
             ensureDirectoriesAreEmpty(directories);
             var metaProperties = StorageTool.buildMetadataProperties(clusterId, config);
-            StorageTool.formatCommand(System.out, directories, metaProperties, MINIMUM_BOOTSTRAP_VERSION, true);
+            StorageTool.formatCommand(LOGGING_PRINT_STREAM, directories, metaProperties, MINIMUM_BOOTSTRAP_VERSION, true);
             return instantiateKraftServer(config, threadNamePrefix);
         }
         else {

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/LoggingPrintStream.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/LoggingPrintStream.java
@@ -11,6 +11,13 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.nio.charset.Charset;
 
+/**
+ * Redirects a {@link PrintStream}'s print calls to the given {@link System.Logger} at
+ * a specified {@link java.lang.System.Logger.Level}. Line feed and/or carriage return characters are
+ * used to as delimiters, separating one log line from the next.
+ * <br/>
+ * The only use-case for this class is to catch a few lines of output from the {@link kafka.tools.StorageTool}.
+ */
 final class LoggingPrintStream {
 
     static PrintStream loggingPrintStream(System.Logger logger, System.Logger.Level level) {
@@ -32,6 +39,7 @@ final class LoggingPrintStream {
 
         @Override
         public void write(int b) {
+            // Note: the use-case of this class is so limited, a byte-by-byte approach is good enough.
             if (b == '\n' || b == '\r') {
                 logPending();
             }

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/LoggingPrintStream.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/LoggingPrintStream.java
@@ -46,13 +46,13 @@ final class LoggingPrintStream {
         }
 
         private void logPending() {
-            if(logger.isLoggable(level) {
-                 var log = os.toString(Charset.defaultCharset()).stripTrailing();
-                 if (!log.isEmpty()) {
-                     logger.log(level, "{0}", log);
-                 }
-                 os.reset();
+            if (logger.isLoggable(level)) {
+                var log = os.toString(Charset.defaultCharset()).stripTrailing();
+                if (!log.isEmpty()) {
+                    logger.log(level, "{0}", log);
+                }
             }
+            os.reset();
         }
     }
 

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/LoggingPrintStream.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/LoggingPrintStream.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.testing.kafka.invm;
+
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.nio.charset.Charset;
+
+final class LoggingPrintStream {
+
+    static PrintStream loggingPrintStream(System.Logger logger, System.Logger.Level level) {
+        return new PrintStream(new LoggingOutputStream(logger, level));
+    }
+
+    private LoggingPrintStream() {
+    }
+
+    private static class LoggingOutputStream extends OutputStream {
+        private final ByteArrayOutputStream os = new ByteArrayOutputStream(1000);
+        private final System.Logger logger;
+        private final System.Logger.Level level;
+
+        public LoggingOutputStream(System.Logger logger, System.Logger.Level level) {
+            this.logger = logger;
+            this.level = level;
+        }
+
+        @Override
+        public void write(int b) {
+            if (b == '\n' || b == '\r') {
+                logPending();
+            }
+            else {
+                os.write(b);
+            }
+        }
+
+        @Override
+        public void close() {
+            logPending();
+        }
+
+        private void logPending() {
+            var log = os.toString(Charset.defaultCharset()).stripTrailing();
+            if (!log.isEmpty()) {
+                logger.log(level, "{0}", log);
+            }
+            os.reset();
+        }
+    }
+
+}

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/LoggingPrintStream.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/LoggingPrintStream.java
@@ -46,11 +46,13 @@ final class LoggingPrintStream {
         }
 
         private void logPending() {
-            var log = os.toString(Charset.defaultCharset()).stripTrailing();
-            if (!log.isEmpty()) {
-                logger.log(level, "{0}", log);
+            if(logger.isLoggable(level) {
+                 var log = os.toString(Charset.defaultCharset()).stripTrailing();
+                 if (!log.isEmpty()) {
+                     logger.log(level, "{0}", log);
+                 }
+                 os.reset();
             }
-            os.reset();
         }
     }
 

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/invm/LoggingPrintStreamTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/invm/LoggingPrintStreamTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package io.kroxylicious.testing.kafka.invm;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class LoggingPrintStreamTest {
+
+    @Mock
+    private System.Logger logger;
+
+    @Test
+    void singleLog() {
+        try (var lps = LoggingPrintStream.loggingPrintStream(logger, System.Logger.Level.INFO)) {
+            lps.println("Hello, world");
+
+            verify(logger, times(1)).log(System.Logger.Level.INFO, "{0}", "Hello, world");
+        }
+        verifyNoMoreInteractions(logger);
+    }
+
+    @Test
+
+    void singleLogGeneratedByManyPrints() {
+        try (var lps = LoggingPrintStream.loggingPrintStream(logger, System.Logger.Level.INFO)) {
+            lps.print("Hello,");
+            lps.println(" world");
+
+            verify(logger, times(1)).log(System.Logger.Level.INFO, "{0}", "Hello, world");
+        }
+        verifyNoMoreInteractions(logger);
+    }
+
+    @Test
+    void twoLogs() {
+        try (var lps = LoggingPrintStream.loggingPrintStream(logger, System.Logger.Level.INFO)) {
+            lps.println("Hello, world");
+            lps.println("Goodbye, cruel world");
+            verify(logger, times(1)).log(System.Logger.Level.INFO, "{0}", "Hello, world");
+            verify(logger, times(1)).log(System.Logger.Level.INFO, "{0}", "Goodbye, cruel world");
+        }
+        verifyNoMoreInteractions(logger);
+    }
+
+    @Test
+    void closeLogsUnfinishedPrint() {
+        try (var lps = LoggingPrintStream.loggingPrintStream(logger, System.Logger.Level.INFO)) {
+            lps.print("There's no newline");
+        }
+
+        verify(logger, times(1)).log(System.Logger.Level.INFO, "{0}", "There's no newline");
+        verifyNoMoreInteractions(logger);
+    }
+
+}

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/invm/LoggingPrintStreamTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/invm/LoggingPrintStreamTest.java
@@ -6,6 +6,8 @@
 
 package io.kroxylicious.testing.kafka.invm;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -14,58 +16,87 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class LoggingPrintStreamTest {
 
+    private static final System.Logger.Level LEVEL = System.Logger.Level.INFO;
     @Mock
     private System.Logger logger;
 
-    @Test
-    void singleLog() {
-        try (var lps = LoggingPrintStream.loggingPrintStream(logger, System.Logger.Level.INFO)) {
-            lps.println("Hello, world");
+    @BeforeEach
+    public void beforeEach() {
+        when(logger.isLoggable(LEVEL)).thenReturn(true);
+    }
 
-            verify(logger, times(1)).log(System.Logger.Level.INFO, "{0}", "Hello, world");
-        }
+    @AfterEach
+    public void afterEach() {
         verifyNoMoreInteractions(logger);
     }
 
     @Test
+    void singleLog() {
+        try (var lps = LoggingPrintStream.loggingPrintStream(logger, LEVEL)) {
+            lps.println("Hello, world");
 
+            verify(logger).log(LEVEL, "{0}", "Hello, world");
+        }
+    }
+
+    @Test
     void singleLogGeneratedByManyPrints() {
-        try (var lps = LoggingPrintStream.loggingPrintStream(logger, System.Logger.Level.INFO)) {
+        try (var lps = LoggingPrintStream.loggingPrintStream(logger, LEVEL)) {
             lps.print("Hello,");
             lps.println(" world");
 
-            verify(logger, times(1)).log(System.Logger.Level.INFO, "{0}", "Hello, world");
+            verify(logger).log(LEVEL, "{0}", "Hello, world");
         }
-        verifyNoMoreInteractions(logger);
     }
 
     @Test
     void twoLogs() {
-        try (var lps = LoggingPrintStream.loggingPrintStream(logger, System.Logger.Level.INFO)) {
+        try (var lps = LoggingPrintStream.loggingPrintStream(logger, LEVEL)) {
             lps.println("Hello, world");
             lps.println("Goodbye, cruel world");
-            verify(logger, times(1)).log(System.Logger.Level.INFO, "{0}", "Hello, world");
-            verify(logger, times(1)).log(System.Logger.Level.INFO, "{0}", "Goodbye, cruel world");
+            verify(logger).log(LEVEL, "{0}", "Hello, world");
+            verify(logger).log(LEVEL, "{0}", "Goodbye, cruel world");
         }
-        verifyNoMoreInteractions(logger);
+    }
+
+    @Test
+    void logsDuplicates() {
+        try (var lps = LoggingPrintStream.loggingPrintStream(logger, LEVEL)) {
+            lps.println("Hello, world");
+            lps.println("Hello, world");
+            verify(logger, times(2)).log(LEVEL, "{0}", "Hello, world");
+        }
+    }
+
+    @Test
+    void respectsDynamicLevelChanges() {
+        when(logger.isLoggable(LEVEL)).thenReturn(false);
+
+        try (var lps = LoggingPrintStream.loggingPrintStream(logger, LEVEL)) {
+            lps.println("I won't be logged");
+            when(logger.isLoggable(LEVEL)).thenReturn(true);
+            lps.println("But I will");
+
+            verify(logger).log(LEVEL, "{0}", "But I will");
+        }
     }
 
     @Test
     void closeLogsUnfinishedPrint() {
         // Given
-        var lps = LoggingPrintStream.loggingPrintStream(logger, System.Logger.Level.INFO)) {
+        var lps = LoggingPrintStream.loggingPrintStream(logger, LEVEL);
         lps.print("There's no newline");
-        
-        //When
+
+        // When
         lps.close();
-        
-        //Then
-        verify(logger, times(1)).log(System.Logger.Level.INFO, "{0}", "There's no newline");
-        verifyNoMoreInteractions(logger);
+
+        // Then
+        verify(logger).log(LEVEL, "{0}", "There's no newline");
     }
 
 }

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/invm/LoggingPrintStreamTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/invm/LoggingPrintStreamTest.java
@@ -56,10 +56,14 @@ class LoggingPrintStreamTest {
 
     @Test
     void closeLogsUnfinishedPrint() {
-        try (var lps = LoggingPrintStream.loggingPrintStream(logger, System.Logger.Level.INFO)) {
-            lps.print("There's no newline");
-        }
-
+        // Given
+        var lps = LoggingPrintStream.loggingPrintStream(logger, System.Logger.Level.INFO)) {
+        lps.print("There's no newline");
+        
+        //When
+        lps.close();
+        
+        //Then
         verify(logger, times(1)).log(System.Logger.Level.INFO, "{0}", "There's no newline");
         verifyNoMoreInteractions(logger);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,7 @@
         <awaitility.version>4.2.0</awaitility.version>
         <annotations.version>24.0.1</annotations.version>
         <duct-tape.version>1.0.8</duct-tape.version>
+        <mockito.version>5.4.0</mockito.version>
         <!-- Avoids issues with ryuk when running with podman https://github.com/containers/podman/issues/7927#issuecomment-731525556 -->
         <testcontainers.ryuk.disabled>true</testcontainers.ryuk.disabled>
     </properties>
@@ -202,6 +203,14 @@
                 <version>${findbugs.annotations.version}</version>
                 <scope>provided</scope>
             </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-bom</artifactId>
+                <version>${mockito.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
### Type of change


- Enhancement / new feature

### Description

Kafka storage formatter is used by the in-VM path.  It currently logs to stdout.  It looks untidy and it means all the diagnostic output isn't in one place.  

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
