### PR TITLE
Make displayname available when using annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Please enumerate all user-facing changes using format `<githib issue/pr number>:
 
 ## 0.5.0
 
+* [#146](https://github.com/kroxylicious/kroxylicious-junit5-extension/pull/146): Expose TestInfo (and thus DisplayName) when clusters are injected via  annotations.
 * [#145](https://github.com/kroxylicious/kroxylicious-junit5-extension/pull/145) Direct storage formatting stdout to the log
 * [#86](https://github.com/kroxylicious/kroxylicious-junit5-extension/issues/86) Added API to restart one or more brokers of a kafka cluster.
 * [#142](https://github.com/kroxylicious/kroxylicious-junit5-extension/pull/142) Prevent spinning in Utils#createTopic.

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -28,6 +28,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -24,5 +24,11 @@
     <description>
     Provides the abstract API for a KafkaCluster and meta-annotation for annotations that constrain provided clusters.
     </description>
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+        </dependency>
+    </dependencies>
 
 </project>

--- a/api/src/main/java/io/kroxylicious/testing/kafka/api/KafkaClusterProvisioningStrategy.java
+++ b/api/src/main/java/io/kroxylicious/testing/kafka/api/KafkaClusterProvisioningStrategy.java
@@ -9,6 +9,8 @@ import java.lang.annotation.Annotation;
 import java.time.Duration;
 import java.util.List;
 
+import org.junit.jupiter.api.TestInfo;
+
 /**
  * Service interface for provisioning.
  */
@@ -40,11 +42,13 @@ public interface KafkaClusterProvisioningStrategy {
 
     /**
      * Create a {@link KafkaCluster} instance with the given configuration.
-     * @param constraints The constraints.
+     *
+     * @param constraints     The constraints.
      * @param declarationType The subtype.
+     * @param testInfo        Information about the test execution context.
      * @return The created instance.
      */
     KafkaCluster create(List<Annotation> constraints,
-                        Class<? extends KafkaCluster> declarationType);
+                        Class<? extends KafkaCluster> declarationType, TestInfo testInfo);
 
 }

--- a/api/src/main/java/io/kroxylicious/testing/kafka/api/KroxyliciousTestInfo.java
+++ b/api/src/main/java/io/kroxylicious/testing/kafka/api/KroxyliciousTestInfo.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.testing.kafka.api;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.TestInfo;
+
+public record KroxyliciousTestInfo(String displayName, Optional<Class<?>> testClass, Optional<Method> testMethod, Set<String> tags) implements TestInfo {
+    @Override
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @Override
+    public Set<String> getTags() {
+        return tags;
+    }
+
+    @Override
+    public Optional<Class<?>> getTestClass() {
+        return testClass;
+    }
+
+    @Override
+    public Optional<Method> getTestMethod() {
+        return testMethod;
+    }
+}

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
@@ -122,10 +122,12 @@ public class KafkaClusterConfig {
      * Build the cluster constraints from the supplied list of annotations.
      *
      * @param annotations the annotations used to configure the KafkaCluster
+     * @param testInfo information about the test execution context.
      * @return the kafka cluster config
      */
-    public static KafkaClusterConfig fromConstraints(List<Annotation> annotations) {
+    public static KafkaClusterConfig fromConstraints(List<Annotation> annotations, TestInfo testInfo) {
         var builder = builder();
+        builder.testInfo(testInfo);
         builder.brokersNum(1);
         boolean sasl = false;
         boolean tls = false;

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMProvisioningStrategy.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMProvisioningStrategy.java
@@ -9,6 +9,8 @@ import java.lang.annotation.Annotation;
 import java.time.Duration;
 import java.util.List;
 
+import org.junit.jupiter.api.TestInfo;
+
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.api.KafkaClusterProvisioningStrategy;
 import io.kroxylicious.testing.kafka.common.KafkaClusterConfig;
@@ -35,8 +37,8 @@ public class InVMProvisioningStrategy implements KafkaClusterProvisioningStrateg
     }
 
     @Override
-    public KafkaCluster create(List<Annotation> constraints, Class<? extends KafkaCluster> declarationType) {
-        KafkaClusterConfig config = KafkaClusterConfig.fromConstraints(constraints);
+    public KafkaCluster create(List<Annotation> constraints, Class<? extends KafkaCluster> declarationType, TestInfo testInfo) {
+        KafkaClusterConfig config = KafkaClusterConfig.fromConstraints(constraints, testInfo);
         return new InVMKafkaCluster(config);
     }
 

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersProvisioningStrategy.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersProvisioningStrategy.java
@@ -9,6 +9,8 @@ import java.lang.annotation.Annotation;
 import java.time.Duration;
 import java.util.List;
 
+import org.junit.jupiter.api.TestInfo;
+
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.api.KafkaClusterProvisioningStrategy;
 import io.kroxylicious.testing.kafka.common.KafkaClusterConfig;
@@ -35,8 +37,8 @@ public class TestcontainersProvisioningStrategy implements KafkaClusterProvision
     }
 
     @Override
-    public KafkaCluster create(List<Annotation> constraints, Class<? extends KafkaCluster> declarationType) {
-        KafkaClusterConfig config = KafkaClusterConfig.fromConstraints(constraints);
+    public KafkaCluster create(List<Annotation> constraints, Class<? extends KafkaCluster> declarationType, TestInfo testInfo) {
+        KafkaClusterConfig config = KafkaClusterConfig.fromConstraints(constraints, testInfo);
         return new TestcontainersKafkaCluster(config);
     }
 

--- a/junit5-extension/src/main/java/io/kroxylicious/testing/kafka/junit5ext/KafkaClusterExtension.java
+++ b/junit5-extension/src/main/java/io/kroxylicious/testing/kafka/junit5ext/KafkaClusterExtension.java
@@ -78,6 +78,7 @@ import org.junit.platform.commons.util.ReflectionUtils;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.api.KafkaClusterConstraint;
 import io.kroxylicious.testing.kafka.api.KafkaClusterProvisioningStrategy;
+import io.kroxylicious.testing.kafka.api.KroxyliciousTestInfo;
 
 import static java.lang.System.Logger.Level.TRACE;
 import static org.junit.platform.commons.support.ReflectionSupport.findFields;
@@ -946,7 +947,7 @@ public class KafkaClusterExtension implements
                 sourceElement,
                 clusterName,
                 best);
-        KafkaCluster c = best.create(constraints, type);
+        KafkaCluster c = best.create(constraints, type, generateTestInfo(extensionContext));
         LOGGER.log(TRACE,
                 "test {0}: decl: {1}: cluster ''{2}'': Created",
                 extensionContext.getUniqueId(),
@@ -954,6 +955,11 @@ public class KafkaClusterExtension implements
                 clusterName);
         c.start();
         return new Closeable<>(sourceElement, clusterName, c);
+    }
+
+    @NotNull
+    private static KroxyliciousTestInfo generateTestInfo(ExtensionContext extensionContext) {
+        return new KroxyliciousTestInfo(extensionContext.getDisplayName(), extensionContext.getTestClass(), extensionContext.getTestMethod(), extensionContext.getTags());
     }
 
     /**


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

Capture TestInfo during cluster creation from the test context so its available when using annotated parameters. This change has the unfortunate side effect of meaning the `testing-api` module now depends on `junit-api` (as we need the TestInfo in the `KafkaClusterProvisioningStrategy`) . Doing so with `provided` scope should limit the implications for downstream users.
 
### Additional Context

ClusterConfig exposes TestInfo which can be useful when generating names/labels for things especially in clusters. However the TestInfo was only set when users created the cluster manually rather than from annotations. 

The implementation is slightly clunky as junit doesn't provide an implementation of `TestInfo` in the public API so we need a record implementing the interface which is slightly annoying as `TestInfo` uses getter style and records use field style access...  

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
