### PR TITLE
Pummel podman

### DIFF
--- a/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
@@ -165,9 +165,9 @@ public class TestcontainersKafkaCluster implements Startable, KafkaCluster, Kafk
         this.name = String.format("%s.%s", Optional.ofNullable(clusterConfig.getTestInfo())
                 .map(TestInfo::getDisplayName)
                 .map(s -> s.replaceFirst("\\(\\)$", ""))
-                .orElse("test_instance"), formatDateTime(OffsetDateTime.now(Clock.systemUTC())));
+                .orElse("test_instance"), OffsetDateTime.now(Clock.systemUTC()));
 
-        logDirVolumeName = this.name + "-logDirVolume";
+        logDirVolumeName = generateLogDirName();
 
         if (this.clusterConfig.isKraftMode()) {
             this.zookeeper = null;
@@ -187,6 +187,14 @@ public class TestcontainersKafkaCluster implements Startable, KafkaCluster, Kafk
         }
 
         clusterConfig.getBrokerConfigs(() -> this).forEach(holder -> brokers.put(holder.getBrokerNum(), buildKafkaContainer(holder)));
+    }
+
+    /**
+     * The volume name must comply with `[a-zA-Z0-9][a-zA-Z0-9_.-]*`
+     */
+    @NotNull
+    private String generateLogDirName() {
+        return String.format("v-%s-logDir", this.name.replaceAll("[^a-zA-Z0-9_.-]", "_"));
     }
 
     @NotNull

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/TemplateTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/TemplateTest.java
@@ -170,6 +170,7 @@ public class TemplateTest {
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     public class Versions {
 
+        // Versions can only be tested using TestContainers.
         @TestTemplate
         public void testVersions(@DimensionMethodSource(value = "versions", clazz = TemplateTest.class) @KRaftCluster TestcontainersKafkaCluster cluster) {
             observedVersions.add(cluster.getKafkaVersion());


### PR DESCRIPTION
### Type of change

_Select the type of your PR_


- Enhancement / new feature

### Description

Add an arbitrary cheap API call to try and ensure the container engine API is available.

### Additional Context

When running on podman on linux repeated executions of `TemplateTest` fail in the `Versions` test (this doesn't happen when run in isolation?!?!). This is currently a tactical hack to ensure the API is available. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
