### PR TITLE
Trap system exit calls from the InVMKafkaCluster

### DIFF
--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
@@ -96,10 +96,7 @@ public class InVMKafkaCluster implements KafkaCluster, KafkaClusterConfig.KafkaE
 
     private static void exitHandler(int statusCode, String message) {
         final IllegalStateException illegalStateException = new IllegalStateException(message);
-        System.out.println("Kafka tried to exit with statusCode: " + statusCode + " and message: " + message);
-        System.out.println("Stack to trace the call");
-        illegalStateException.printStackTrace(System.out);
-        LOGGER.log(System.Logger.Level.WARNING, "Kafka tried to exit with statusCode: {0} and message: {1}. Dumping stack to trace whats at fault",
+        LOGGER.log(System.Logger.Level.WARNING, "Kafka tried to exit with statusCode: {0} and message: {1}. Including stacktrace to determine whats at fault",
                 statusCode, message, illegalStateException);
     }
 

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
@@ -432,9 +432,12 @@ public class InVMKafkaCluster implements KafkaCluster, KafkaClusterConfig.KafkaE
 
     private static void trapKafkaSystemExit() {
         Exit.setExitProcedure((statusCode, message) -> {
+            final IllegalStateException illegalStateException = new IllegalStateException(message);
+            System.out.println("Kafka tried to exit with statusCode: " + statusCode + " and message: " + message);
+            System.out.println("Stack to trace the call");
+            illegalStateException.printStackTrace(System.out);
             LOGGER.log(System.Logger.Level.WARNING, "Kafka tried to exit with statusCode: {0} and message: {1}. Dumping stack to trace whats at fault",
-                    statusCode, message, new IllegalStateException(message));
-            System.out.println("Avoiding shutdown  with code: " + statusCode + " and message: " + message);
+                    statusCode, message, illegalStateException);
         });
     }
 

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/common/ListeningSocketPreallocatorTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/common/ListeningSocketPreallocatorTest.java
@@ -27,7 +27,7 @@ class ListeningSocketPreallocatorTest {
     }
 
     @ParameterizedTest
-    @ValueSource(ints = { 1, 5, 100, 10_000 })
+    @ValueSource(ints = { 1, 5, 100, 5_000 })
     void shouldAllocateOpenSockets(int numPorts) {
         var sockets = preallocator.preAllocateListeningSockets(numPorts);
         assertThat(sockets).hasSize(numPorts);
@@ -39,7 +39,7 @@ class ListeningSocketPreallocatorTest {
     }
 
     @ParameterizedTest
-    @ValueSource(ints = { 1, 5, 100, 10_000 })
+    @ValueSource(ints = { 1, 5, 100, 5_000 })
     void shouldCreateDistinctPorts(int numPorts) {
         // Given
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

This PR overrides the default SystemExit handler in Kafka to ensure the error is logged and a stack to trace it

### Additional Context

Kafka has a habit of committing seppuku when a variety of nasty things go wrong. This is *ahem* problematic in test suites. Luckily we can trap the call and suppress it to allow the tests to fail normally.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
