### PR TITLE
Integration tests not running in IDEA

### DIFF
--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -82,8 +82,9 @@
             <version>${junit.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-suite-engine</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Enable ExceptionalTest to run in IDEA, the constellation of junit dependencies we had meant that the IDEA running only ran with the `junit-platform-suite-engine` on the classpath, but the maven surefire tests were running with `junit-jupiter-engine` and `junit-vintage-engine` on the classpath. The surefire plugin has some smarts around automatically adding engines based on what dependencies are on your test path.

```
[roby@roby kroxylicious-junit5-extension]$ mvn surefire:test -pl :testing-integration-test -X | grep "Test dependencies contain"
[DEBUG] Test dependencies contain org.junit.jupiter:junit-jupiter-api. Resolving org.junit.jupiter:junit-jupiter-engine:5.10.0
[DEBUG] Test dependencies contain JUnit4. Resolving org.junit.vintage:junit-vintage-engine:5.10.0
```

This leads to different test discovery strategies in IDEA and surefire. IDEA was only looking for classes with the `@Suite` annotation.

### Additional Context

Intellij was unable to run the integration-tests, reporting zero tests found if you tried to run the tests for the module or the source root.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
