### PR TITLE
Support Multiple controllers

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -45,7 +45,7 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
 
-      - name: 'Build example service'
+      - name: 'Build junit extension with maven tests'
         run: mvn -B clean verify -Pci
 
       - name: 'Run tests in containers'

--- a/README.md
+++ b/README.md
@@ -74,6 +74,17 @@ When multiple constraints are provided they will _all_ be satisfied.
 
 The cluster will be provisioned using the fastest available mechanism, because your development inner loop is a precious thing.
 
+## Provisioning topology
+
+In kraft cluster (the default) the extension will generate nodes using the `broker, controller` roles until it reaches the desired number of brokers or controllers (which ever is lowest) at which point it will continue deploying the remaining role.
+
+| numBrokers | numControllers | roles                                                               |
+|------------|----------------|---------------------------------------------------------------------|
+| 1          | 1              | `"broker,controller"`                                               |
+| 3          | 1              | `"broker,controller"`, `"broker"`, `"broker"`                       |
+| 1          | 3              | `"broker,controller"`, `"controller"`, `"controller"`               |
+| 3          | 3              | `"broker,controller"`, `"broker,controller"`, `"broker,controller"` |
+
 ## Provisioning mechanisms
 
 The following provisioning mechanisms are currently supported:
@@ -231,6 +242,3 @@ See the [developer guide](DEV_GUIDE.md).
 ## Releasing this project
 
 See the [releasing guide](RELEASING.md).
-
-
-

--- a/README.md
+++ b/README.md
@@ -74,9 +74,10 @@ When multiple constraints are provided they will _all_ be satisfied.
 
 The cluster will be provisioned using the fastest available mechanism, because your development inner loop is a precious thing.
 
-## Provisioning topology
+## Node topology
 
-In a kraft cluster (the default) the extension will generate nodes using the `broker, controller` roles until it reaches the desired number of brokers or controllers (which ever is lowest) at which point it will continue deploying the remaining role.
+When generating a cluster using KRaft (the default), you declare how many brokers and controllers you want and the extension will provision the minimum number of nodes to satisfy those conditions. It will create as many nodes as it can that are both KRaft controllers and brokers using [process.roles](https://kafka.apache.org/documentation/#brokerconfigs_process.roles) (process.roles = "broker,controller"). For example:
+
 
 | numBrokers | numControllers | roles                                                               |
 |------------|----------------|---------------------------------------------------------------------|

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The cluster will be provisioned using the fastest available mechanism, because y
 
 ## Provisioning topology
 
-In kraft cluster (the default) the extension will generate nodes using the `broker, controller` roles until it reaches the desired number of brokers or controllers (which ever is lowest) at which point it will continue deploying the remaining role.
+In a kraft cluster (the default) the extension will generate nodes using the `broker, controller` roles until it reaches the desired number of brokers or controllers (which ever is lowest) at which point it will continue deploying the remaining role.
 
 | numBrokers | numControllers | roles                                                               |
 |------------|----------------|---------------------------------------------------------------------|

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/BrokerCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/BrokerCluster.java
@@ -78,10 +78,12 @@ public @interface BrokerCluster {
      * Number of brokers in the cluster
      * The extension will combine this with the <code>numControllers</code> when in Kraft mode to generate a cluster topology.
      * <table>
+     *  <caption>Breakdown of the interaction between numControllers and numBrokers</caption>
      *  <tr><th>numBrokers</th><th>numControllers</th><th>roles</th></tr>
      *  <tr><td>1</td><td>1</td><td><code>"broker,controller"</code></td></tr>
      *  <tr><td>3</td><td>1</td><td><code>"broker,controller"</code>, <code>"broker"</code>, <code>"broker"</code></td></tr>
      *  <tr><td>1</td><td>3</td><td><code>"broker,controller"</code>, <code>"controller"</code>, <code>"controller"</code></td></tr>
+     *  <tr><td>3</td><td>3</td><td><code>"broker,controller"</code>, <code>"broker,controller"</code>, <code>"broker,controller"</code></td></tr>
      * </table>
      * @return The number of brokers in the cluster
      */

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/BrokerCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/BrokerCluster.java
@@ -76,6 +76,13 @@ import io.kroxylicious.testing.kafka.api.KafkaClusterConstraint;
 public @interface BrokerCluster {
     /**
      * Number of brokers in the cluster
+     * The extension will combine this with the <code>numControllers</code> when in Kraft mode to generate a cluster topology.
+     * <table>
+     *  <tr><th>numBrokers</th><th>numControllers</th><th>roles</th></tr>
+     *  <tr><td>1</td><td>1</td><td><code>"broker,controller"</code></td></tr>
+     *  <tr><td>3</td><td>1</td><td><code>"broker,controller"</code>, <code>"broker"</code>, <code>"broker"</code></td></tr>
+     *  <tr><td>1</td><td>3</td><td><code>"broker,controller"</code>, <code>"controller"</code>, <code>"controller"</code></td></tr>
+     * </table>
      * @return The number of brokers in the cluster
      */
     // TODO should this be minBrokers?

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KRaftCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KRaftCluster.java
@@ -27,10 +27,12 @@ public @interface KRaftCluster {
      * The extension will ensure there are enough nodes started with the <code>controller</code> role.
      * The extension will combine this with the <code>numBrokers</code> to generate a cluster topology.
      * <table>
+     *  <caption>Breakdown of the interaction between numControllers and numBrokers</caption>
      *  <tr><th>numBrokers</th><th>numControllers</th><th>roles</th></tr>
      *  <tr><td>1</td><td>1</td><td><code>"broker,controller"</code></td></tr>
      *  <tr><td>3</td><td>1</td><td><code>"broker,controller"</code>, <code>"broker"</code>, <code>"broker"</code></td></tr>
      *  <tr><td>1</td><td>3</td><td><code>"broker,controller"</code>, <code>"controller"</code>, <code>"controller"</code></td></tr>
+     *  <tr><td>3</td><td>3</td><td><code>"broker,controller"</code>, <code>"broker,controller"</code>, <code>"broker,controller"</code></td></tr>
      * </table>
      * @return The number of KRaft controllers
      */

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KRaftCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KRaftCluster.java
@@ -24,6 +24,14 @@ import io.kroxylicious.testing.kafka.api.KafkaClusterProvisioningStrategy;
 public @interface KRaftCluster {
     /**
      * The number of kraft controllers
+     * The extension will ensure there are enough nodes started with the <code>controller</code> role.
+     * The extension will combine this with the <code>numBrokers</code> to generate a cluster topology.
+     * <table>
+     *  <tr><th>numBrokers</th><th>numControllers</th><th>roles</th></tr>
+     *  <tr><td>1</td><td>1</td><td><code>"broker,controller"</code></td></tr>
+     *  <tr><td>3</td><td>1</td><td><code>"broker,controller"</code>, <code>"broker"</code>, <code>"broker"</code></td></tr>
+     *  <tr><td>1</td><td>3</td><td><code>"broker,controller"</code>, <code>"controller"</code>, <code>"controller"</code></td></tr>
+     * </table>
      * @return The number of KRaft controllers
      */
     public int numControllers() default 1;

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
@@ -302,13 +302,19 @@ public class KafkaClusterConfig {
     private String determineRole(int nodeId) {
         var roles = new ArrayList<String>();
 
-        if (nodeId < brokersNum) {
+        if (nodeId < brokersNum || isAdditionalNode(nodeId)) {
             roles.add(BROKER_ROLE);
         }
         if (nodeId < kraftControllers) {
             roles.add(CONTROLLER_ROLE);
         }
         return String.join(",", roles);
+    }
+
+    // additional nodes can only be added after the initial topology is generated.
+    // Hence, it is safe to assume that a node is additional if it has a higherId than the initial topology would allow for.
+    private boolean isAdditionalNode(int nodeId) {
+        return nodeId >= Math.max(brokersNum, kraftControllers);
     }
 
     private void configureTls(KafkaEndpoints.EndpointPair clientEndpoint, Properties server) {

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
@@ -52,9 +52,13 @@ public class KafkaClusterConfig {
 
     private static final System.Logger LOGGER = System.getLogger(KafkaClusterConfig.class.getName());
     private static final String ONE_CONFIG = Integer.toString(1);
-    public static final String CONTROLLER_LISTENER_NAME = "CONTROLLER";
     public static final String BROKER_ROLE = "broker";
     public static final String CONTROLLER_ROLE = "controller";
+
+    public static final String CONTROLLER_LISTENER_NAME = "CONTROLLER";
+    public static final String EXTERNAL_LISTENER_NAME = "EXTERNAL";
+    public static final String INTERNAL_LISTENER_NAME = "INTERNAL";
+    public static final String ANON_LISTENER_NAME = "ANON";
 
     private TestInfo testInfo;
     private KeytoolCertificateGenerator brokerKeytoolCertificateGenerator;
@@ -357,31 +361,31 @@ public class KafkaClusterConfig {
 
             // TODO support other than PLAIN
             String plainModuleConfig = String.format("org.apache.kafka.common.security.plain.PlainLoginModule required %s;", saslPairs);
-            putConfig(server, String.format("listener.name.%s.plain.sasl.jaas.config", "EXTERNAL".toLowerCase()), plainModuleConfig);
+            putConfig(server, String.format("listener.name.%s.plain.sasl.jaas.config", EXTERNAL_LISTENER_NAME.toLowerCase()), plainModuleConfig);
         }
     }
 
     private static void configureInternalListener(TreeMap<String, String> protocolMap, TreeMap<String, String> listeners, KafkaEndpoints.EndpointPair interBrokerEndpoint,
                                                   TreeMap<String, String> advertisedListeners, TreeSet<String> earlyStart, Properties server) {
-        protocolMap.put("INTERNAL", SecurityProtocol.PLAINTEXT.name());
-        listeners.put("INTERNAL", interBrokerEndpoint.listenAddress());
-        advertisedListeners.put("INTERNAL", interBrokerEndpoint.advertisedAddress());
-        earlyStart.add("INTERNAL");
-        putConfig(server, "inter.broker.listener.name", "INTERNAL");
+        protocolMap.put(INTERNAL_LISTENER_NAME, SecurityProtocol.PLAINTEXT.name());
+        listeners.put(INTERNAL_LISTENER_NAME, interBrokerEndpoint.listenAddress());
+        advertisedListeners.put(INTERNAL_LISTENER_NAME, interBrokerEndpoint.advertisedAddress());
+        earlyStart.add(INTERNAL_LISTENER_NAME);
+        putConfig(server, "inter.broker.listener.name", INTERNAL_LISTENER_NAME);
     }
 
     private static void configureAnonListener(TreeMap<String, String> protocolMap, TreeMap<String, String> listeners, KafkaEndpoints.EndpointPair anonEndpoint,
                                               TreeMap<String, String> advertisedListeners) {
-        protocolMap.put("ANON", SecurityProtocol.PLAINTEXT.name());
-        listeners.put("ANON", anonEndpoint.listenAddress());
-        advertisedListeners.put("ANON", anonEndpoint.advertisedAddress());
+        protocolMap.put(ANON_LISTENER_NAME, SecurityProtocol.PLAINTEXT.name());
+        listeners.put(ANON_LISTENER_NAME, anonEndpoint.listenAddress());
+        advertisedListeners.put(ANON_LISTENER_NAME, anonEndpoint.advertisedAddress());
     }
 
     private static void configureExternalListener(TreeMap<String, String> protocolMap, String externalListenerTransport, TreeMap<String, String> listeners,
                                                   KafkaEndpoints.EndpointPair clientEndpoint, TreeMap<String, String> advertisedListeners) {
-        protocolMap.put("EXTERNAL", externalListenerTransport);
-        listeners.put("EXTERNAL", clientEndpoint.listenAddress());
-        advertisedListeners.put("EXTERNAL", clientEndpoint.advertisedAddress());
+        protocolMap.put(EXTERNAL_LISTENER_NAME, externalListenerTransport);
+        listeners.put(EXTERNAL_LISTENER_NAME, clientEndpoint.listenAddress());
+        advertisedListeners.put(EXTERNAL_LISTENER_NAME, clientEndpoint.advertisedAddress());
     }
 
     private static void configureLegacyNode(KafkaEndpoints kafkaEndpoints, Properties server) {

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
@@ -296,14 +296,15 @@ public class KafkaClusterConfig {
 
     @NotNull
     private String determineRole(int nodeId) {
-        var role = BROKER_ROLE;
-        if (nodeId < kraftControllers && nodeId < brokersNum) {
-            role = "broker,controller";
+        var roles = new ArrayList<String>();
+
+        if (nodeId < brokersNum) {
+            roles.add(BROKER_ROLE);
         }
-        else if (nodeId < kraftControllers && nodeId >= brokersNum) {
-            role = CONTROLLER_ROLE;
+        if (nodeId < kraftControllers) {
+            roles.add(CONTROLLER_ROLE);
         }
-        return role;
+        return String.join(",", roles);
     }
 
     private void configureTls(KafkaEndpoints.EndpointPair clientEndpoint, Properties server) {

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterFactory.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterFactory.java
@@ -61,14 +61,8 @@ public class KafkaClusterFactory {
             throw new NullPointerException();
         }
 
-        var clusterMode = KafkaClusterExecutionMode.convertClusterExecutionMode(System.getenv().get(TEST_CLUSTER_EXECUTION_MODE),
-                clusterConfig.getExecMode() == null ? KafkaClusterExecutionMode.IN_VM : clusterConfig.getExecMode());
+        var clusterMode = getExecutionMode(clusterConfig);
         var kraftMode = convertClusterKraftMode(System.getenv().get(TEST_CLUSTER_KRAFT_MODE), true);
-        if (KafkaClusterExecutionMode.CONTAINER == clusterMode && kraftMode && clusterConfig.getBrokersNum() < clusterConfig.getKraftControllers()) {
-            throw new IllegalStateException(
-                    "Due to https://github.com/ozangunalp/kafka-native/issues/88 we can't support controller only nodes so we need to fail fast. This cluster has "
-                            + clusterConfig.getBrokersNum() + " brokers and " + clusterConfig.getKraftControllers() + " controllers");
-        }
         var builder = clusterConfig.toBuilder();
 
         if (clusterConfig.getExecMode() == null) {
@@ -77,6 +71,12 @@ public class KafkaClusterFactory {
 
         if (clusterConfig.getKraftMode() == null) {
             builder.kraftMode(kraftMode);
+        }
+
+        if (KafkaClusterExecutionMode.CONTAINER == clusterMode && kraftMode && clusterConfig.getBrokersNum() < clusterConfig.getKraftControllers()) {
+            throw new IllegalStateException(
+                    "Due to https://github.com/ozangunalp/kafka-native/issues/88 we can't support controller only nodes so we need to fail fast. This cluster has "
+                            + clusterConfig.getBrokersNum() + " brokers and " + clusterConfig.getKraftControllers() + " controllers");
         }
 
         var kafkaVersion = System.getenv().getOrDefault(KAFKA_VERSION, "latest");
@@ -96,6 +96,11 @@ public class KafkaClusterFactory {
 
             return new TestcontainersKafkaCluster(kafkaImage, zookeeperImage, actual);
         }
+    }
+
+    private static KafkaClusterExecutionMode getExecutionMode(KafkaClusterConfig clusterConfig) {
+        return KafkaClusterExecutionMode.convertClusterExecutionMode(System.getenv().get(TEST_CLUSTER_EXECUTION_MODE),
+                clusterConfig.getExecMode() == null ? KafkaClusterExecutionMode.IN_VM : clusterConfig.getExecMode());
     }
 
     private static boolean convertClusterKraftMode(String mode, boolean defaultMode) {

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterFactory.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterFactory.java
@@ -75,7 +75,8 @@ public class KafkaClusterFactory {
 
         if (KafkaClusterExecutionMode.CONTAINER == clusterMode && kraftMode && clusterConfig.getBrokersNum() < clusterConfig.getKraftControllers()) {
             throw new IllegalStateException(
-                    "Due to https://github.com/ozangunalp/kafka-native/issues/88 we can't support controller only nodes so we need to fail fast. This cluster has "
+                    "Due to https://github.com/ozangunalp/kafka-native/issues/88 we can't support controller only nodes in " + KafkaClusterExecutionMode.CONTAINER
+                            + " mode so we need to fail fast. This cluster has "
                             + clusterConfig.getBrokersNum() + " brokers and " + clusterConfig.getKraftControllers() + " controllers");
         }
 

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/Utils.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/Utils.java
@@ -210,9 +210,9 @@ public class Utils {
                 .all()
                 .toCompletionStage()
                 .thenRun(() -> log.debug("Create future for topic {} completed.", CONSISTENCY_TEST))
-                .exceptionallyComposeAsync((throwable) -> {
+                .exceptionallyComposeAsync(throwable -> {
                     log.warn("Failed to create topic: {} due to {}", CONSISTENCY_TEST, throwable.getMessage());
-                    if (isRetriable(throwable)) {
+                    if (isRetryable(throwable)) {
                         // Retry the creation of the topic. The delayed executor used in this stage's handling avoids
                         // a tight spinning loop.
                         return createTopic(expectedBrokerCount, admin);
@@ -223,7 +223,7 @@ public class Utils {
                 }, CompletableFuture.delayedExecutor(100, TimeUnit.MILLISECONDS));
     }
 
-    private static boolean isRetriable(Throwable potentiallyWrapped) {
+    private static boolean isRetryable(Throwable potentiallyWrapped) {
         // If the throwable originates from within a CompletionStage's handler, it will be wrapped within a
         // CompletionException.
         var throwable = potentiallyWrapped instanceof CompletionException && potentiallyWrapped.getCause() != null ? potentiallyWrapped.getCause() : potentiallyWrapped;

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
@@ -187,6 +187,7 @@ public class TestcontainersKafkaCluster implements Startable, KafkaCluster, Kafk
 
         try (PortAllocator.PortAllocationSession portAllocationSession = portsAllocator.allocationSession()) {
             portAllocationSession.allocate(Set.of(Listener.EXTERNAL, Listener.ANON), 0, clusterConfig.getBrokersNum());
+            portAllocationSession.allocate(Set.of(Listener.CONTROLLER), 0, clusterConfig.getKraftControllers());
         }
 
         clusterConfig.getBrokerConfigs(() -> this).forEach(holder -> nodes.put(holder.getBrokerNum(), buildKafkaContainer(holder)));

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
@@ -216,7 +216,7 @@ public class TestcontainersKafkaCluster implements Startable, KafkaCluster, Kafk
                 // KAFKA_LOG_DIR overrides a key in the quarkus kafka image application.properties. The quarkus app uses
                 // that to set log.dir. Any value we set for log.dir in server.properties is lost.
                 .withEnv("KAFKA_LOG_DIR", getBrokerLogDirectory(holder.getBrokerNum()))
-                .withEnv("QUARKUS_LOG_LEVEL", "DEBUG") // Enables org.apache.kafka logging too
+//                .withEnv("QUARKUS_LOG_LEVEL", "DEBUG") // Enables org.apache.kafka logging too
                 .withEnv("SERVER_PROPERTIES_FILE", "/cnf/server.properties")
                 .withEnv("SERVER_CLUSTER_ID", holder.getKafkaKraftClusterId())
                 .withCopyToContainer(Transferable.of(propertiesToBytes(holder.getProperties()), 0644), "/cnf/server.properties")

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
@@ -755,7 +755,7 @@ public class TestcontainersKafkaCluster implements Startable, KafkaCluster, Kafk
                 target = target.resolve(String.format("%s.%s.%s", getContainerName().replaceFirst(File.separator, ""), getContainerId(), "log"));
                 target.getParent().toFile().mkdirs();
                 try (var writer = new FileWriter(target.toFile())) {
-                    LOGGER.log(Level.INFO, "writing logs for {0} to {1}", getContainerName(), target);
+                    LOGGER.log(Level.DEBUG, "writing logs for {0} to {1}", getContainerName(), target);
                     super.followOutput(outputFrame -> {
                         try {
                             if (outputFrame.equals(OutputFrame.END)) {

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
@@ -16,6 +16,7 @@ import java.nio.file.Path;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -94,6 +95,8 @@ public class TestcontainersKafkaCluster implements Startable, KafkaCluster, Kafk
     private static final Duration STARTUP_TIMEOUT = Duration.ofMinutes(2);
     private static final Duration RESTART_BACKOFF_DELAY = Duration.ofMillis(2500);
 
+    private static final DateTimeFormatter NAME_DATE_TIME_FORMAT = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss");
+
     // If Zookeeper or Kafka run for less than 500ms, there's almost certainly a problem. This makes it be treated
     // as a startup failure.
     private static final Duration MINIMUM_RUNNING_DURATION = Duration.ofMillis(500);
@@ -164,7 +167,7 @@ public class TestcontainersKafkaCluster implements Startable, KafkaCluster, Kafk
         this.name = Optional.ofNullable(clusterConfig.getTestInfo())
                 .map(TestInfo::getDisplayName)
                 .map(s -> s.replaceFirst("\\(\\)$", ""))
-                .map(s -> String.format("%s.%s", s, OffsetDateTime.now(Clock.systemUTC())))
+                .map(s -> String.format("%s.%s", s, NAME_DATE_TIME_FORMAT.format(OffsetDateTime.now(Clock.systemUTC()))))
                 .orElse(null);
 
         if (this.clusterConfig.isKraftMode()) {

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
@@ -181,7 +181,6 @@ public class TestcontainersKafkaCluster implements Startable, KafkaCluster, Kafk
                     .withNetwork(network)
                     .withMinimumRunningDuration(MINIMUM_RUNNING_DURATION)
                     .withStartupAttempts(CONTAINER_STARTUP_ATTEMPTS)
-                    // .withEnv("QUARKUS_LOG_LEVEL", "DEBUG") // Enables org.apache.zookeeper logging too
                     .withNetworkAliases("zookeeper");
         }
 
@@ -216,7 +215,6 @@ public class TestcontainersKafkaCluster implements Startable, KafkaCluster, Kafk
                 // KAFKA_LOG_DIR overrides a key in the quarkus kafka image application.properties. The quarkus app uses
                 // that to set log.dir. Any value we set for log.dir in server.properties is lost.
                 .withEnv("KAFKA_LOG_DIR", getBrokerLogDirectory(holder.getBrokerNum()))
-                // .withEnv("QUARKUS_LOG_LEVEL", "DEBUG") // Enables org.apache.kafka logging too
                 .withEnv("SERVER_PROPERTIES_FILE", "/cnf/server.properties")
                 .withEnv("SERVER_CLUSTER_ID", holder.getKafkaKraftClusterId())
                 .withCopyToContainer(Transferable.of(propertiesToBytes(holder.getProperties()), 0644), "/cnf/server.properties")

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
@@ -216,7 +216,7 @@ public class TestcontainersKafkaCluster implements Startable, KafkaCluster, Kafk
                 // KAFKA_LOG_DIR overrides a key in the quarkus kafka image application.properties. The quarkus app uses
                 // that to set log.dir. Any value we set for log.dir in server.properties is lost.
                 .withEnv("KAFKA_LOG_DIR", getBrokerLogDirectory(holder.getBrokerNum()))
-//                .withEnv("QUARKUS_LOG_LEVEL", "DEBUG") // Enables org.apache.kafka logging too
+                // .withEnv("QUARKUS_LOG_LEVEL", "DEBUG") // Enables org.apache.kafka logging too
                 .withEnv("SERVER_PROPERTIES_FILE", "/cnf/server.properties")
                 .withEnv("SERVER_CLUSTER_ID", holder.getKafkaKraftClusterId())
                 .withCopyToContainer(Transferable.of(propertiesToBytes(holder.getProperties()), 0644), "/cnf/server.properties")

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
@@ -209,8 +209,11 @@ public class TestcontainersKafkaCluster implements Startable, KafkaCluster, Kafk
                 .withStartupAttempts(CONTAINER_STARTUP_ATTEMPTS)
                 .withMinimumRunningDuration(MINIMUM_RUNNING_DURATION)
                 .withStartupTimeout(STARTUP_TIMEOUT);
-        kafkaContainer.addFixedExposedPort(holder.getExternalPort(), CLIENT_PORT);
-        kafkaContainer.addFixedExposedPort(holder.getAnonPort(), ANON_PORT);
+
+        if (isBroker(holder.getBrokerNum())) {
+            kafkaContainer.addFixedExposedPort(holder.getExternalPort(), CLIENT_PORT);
+            kafkaContainer.addFixedExposedPort(holder.getAnonPort(), ANON_PORT);
+        }
         kafkaContainer.addGenericBind(new Bind(logDirVolumeName, new Volume(KAFKA_CONTAINER_MOUNT_POINT)));
 
         if (!clusterConfig.isKraftMode()) {
@@ -642,6 +645,18 @@ public class TestcontainersKafkaCluster implements Startable, KafkaCluster, Kafk
         catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private boolean isController(Integer key) {
+        // TODO this is nasty. We shouldn't need to go via the portAllocator to figure out what a node is
+        // But it is at least testing something meaningful about the configuration
+        return portsAllocator.hasRegisteredPort(Listener.CONTROLLER, key);
+    }
+
+    private boolean isBroker(Integer key) {
+        // TODO this is nasty. We shouldn't need to go via the portAllocator to figure out what a node is
+        // But it is at least testing something meaningful about the configuration
+        return portsAllocator.hasRegisteredPort(Listener.ANON, key);
     }
 
     /**

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/KafkaClusterTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/KafkaClusterTest.java
@@ -54,7 +54,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * Test case that simply exercises the ability to control the kafka cluster from the test.
  */
-public class KafkaClusterTest {
+class KafkaClusterTest {
 
     private static final System.Logger LOGGER = System.getLogger(KafkaClusterTest.class.getName());
     private TestInfo testInfo;
@@ -62,7 +62,7 @@ public class KafkaClusterTest {
     private KeytoolCertificateGenerator clientKeytoolCertificateGenerator;
 
     @Test
-    public void kafkaClusterKraftMode() throws Exception {
+    void kafkaClusterKraftMode() throws Exception {
         try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
                 .testInfo(testInfo)
                 .kraftMode(true)
@@ -73,7 +73,7 @@ public class KafkaClusterTest {
     }
 
     @Test
-    public void kafkaClusterZookeeperMode() throws Exception {
+    void kafkaClusterZookeeperMode() throws Exception {
         try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
                 .testInfo(testInfo)
                 .kraftMode(false)
@@ -85,7 +85,7 @@ public class KafkaClusterTest {
 
     @ParameterizedTest
     @ValueSource(booleans = { true, false })
-    public void kafkaClusterAddBroker(boolean kraft) throws Exception {
+    void kafkaClusterAddBroker(boolean kraft) throws Exception {
         int brokersNum = 1;
         try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
                 .testInfo(testInfo)
@@ -117,7 +117,7 @@ public class KafkaClusterTest {
 
     @ParameterizedTest
     @MethodSource
-    public void stopAndStartBrokers(int brokersNum, boolean kraft, TerminationStyle terminationStyle, Predicate<Integer> brokerPredicate) throws Exception {
+    void stopAndStartBrokers(int brokersNum, boolean kraft, TerminationStyle terminationStyle, Predicate<Integer> brokerPredicate) throws Exception {
         try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
                 .testInfo(testInfo)
                 .brokersNum(brokersNum)
@@ -150,7 +150,7 @@ public class KafkaClusterTest {
 
     @ParameterizedTest
     @ValueSource(booleans = { true, false })
-    public void stopAndStartIdempotency(boolean kraft) throws Exception {
+    void stopAndStartIdempotency(boolean kraft) throws Exception {
         try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
                 .testInfo(testInfo)
                 .kraftMode(kraft)
@@ -182,7 +182,7 @@ public class KafkaClusterTest {
 
     @ParameterizedTest
     @ValueSource(booleans = { true, false })
-    public void stopAndStartIncrementally(boolean kraft) throws Exception {
+    void stopAndStartIncrementally(boolean kraft) throws Exception {
         try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
                 .testInfo(testInfo)
                 .kraftMode(kraft)
@@ -210,7 +210,7 @@ public class KafkaClusterTest {
 
     @ParameterizedTest
     @ValueSource(booleans = { true, false })
-    public void topicPersistsThroughStopAndStart(boolean kraft) throws Exception {
+    void topicPersistsThroughStopAndStart(boolean kraft) throws Exception {
         try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
                 .testInfo(testInfo)
                 .kraftMode(kraft)
@@ -240,7 +240,7 @@ public class KafkaClusterTest {
     }
 
     @Test
-    public void kafkaTwoNodeClusterKraftMode() throws Exception {
+    void kafkaTwoNodeClusterKraftMode() throws Exception {
         int brokersNum = 2;
         try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
                 .testInfo(testInfo)
@@ -253,7 +253,7 @@ public class KafkaClusterTest {
     }
 
     @Test
-    public void kafkaTwoNodeClusterZookeeperMode() throws Exception {
+    void kafkaTwoNodeClusterZookeeperMode() throws Exception {
         int brokersNum = 2;
         try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
                 .testInfo(testInfo)
@@ -267,7 +267,7 @@ public class KafkaClusterTest {
 
     @ParameterizedTest
     @ValueSource(booleans = { true, false })
-    public void kafkaClusterRemoveBroker(boolean kraft) throws Exception {
+    void kafkaClusterRemoveBroker(boolean kraft) throws Exception {
         int brokersNum = 3;
         try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
                 .testInfo(testInfo)
@@ -289,7 +289,7 @@ public class KafkaClusterTest {
 
     @ParameterizedTest
     @ValueSource(booleans = { true, false })
-    public void kafkaClusterRemoveWithStoppedBrokerDisallowed(boolean kraft) throws Exception {
+    void kafkaClusterRemoveWithStoppedBrokerDisallowed(boolean kraft) throws Exception {
         int brokersNum = 2;
         try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
                 .testInfo(testInfo)
@@ -307,7 +307,7 @@ public class KafkaClusterTest {
     }
 
     @Test
-    public void kafkaClusterKraftDisallowsControllerRemoval() throws Exception {
+    void kafkaClusterKraftDisallowsControllerRemoval() throws Exception {
         int brokersNum = 1;
         try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
                 .testInfo(testInfo)
@@ -323,7 +323,7 @@ public class KafkaClusterTest {
     }
 
     @Test
-    public void kafkaClusterKraftModeWithAuth() throws Exception {
+    void kafkaClusterKraftModeWithAuth() throws Exception {
         try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
                 .kraftMode(true)
                 .testInfo(testInfo)
@@ -337,7 +337,7 @@ public class KafkaClusterTest {
     }
 
     @Test
-    public void kafkaClusterZookeeperModeWithAuth() throws Exception {
+    void kafkaClusterZookeeperModeWithAuth() throws Exception {
         try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
                 .testInfo(testInfo)
                 .kraftMode(false)
@@ -351,7 +351,7 @@ public class KafkaClusterTest {
     }
 
     @Test
-    public void kafkaClusterKraftModeSASL_SSL_ClientUsesSSLClientAuth() throws Exception {
+    void kafkaClusterKraftModeSASL_SSL_ClientUsesSSLClientAuth() throws Exception {
         createClientCertificate();
         try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
                 .testInfo(testInfo)
@@ -368,7 +368,7 @@ public class KafkaClusterTest {
     }
 
     @Test
-    public void kafkaClusterKraftModeSSL_ClientUsesSSLClientAuth() throws Exception {
+    void kafkaClusterKraftModeSSL_ClientUsesSSLClientAuth() throws Exception {
         createClientCertificate();
         try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
                 .testInfo(testInfo)
@@ -383,7 +383,7 @@ public class KafkaClusterTest {
     }
 
     @Test
-    public void kafkaClusterZookeeperModeSASL_SSL_ClientUsesSSLClientAuth() throws Exception {
+    void kafkaClusterZookeeperModeSASL_SSL_ClientUsesSSLClientAuth() throws Exception {
         createClientCertificate();
         try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
                 .testInfo(testInfo)
@@ -400,7 +400,7 @@ public class KafkaClusterTest {
     }
 
     @Test
-    public void kafkaClusterZookeeperModeSSL_ClientUsesSSLClientAuth() throws Exception {
+    void kafkaClusterZookeeperModeSSL_ClientUsesSSLClientAuth() throws Exception {
         createClientCertificate();
         try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
                 .testInfo(testInfo)
@@ -415,7 +415,7 @@ public class KafkaClusterTest {
     }
 
     @Test
-    public void kafkaClusterKraftModeSSL_ClientNoAuth() throws Exception {
+    void kafkaClusterKraftModeSSL_ClientNoAuth() throws Exception {
         try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
                 .testInfo(testInfo)
                 .brokerKeytoolCertificateGenerator(brokerKeytoolCertificateGenerator)
@@ -428,7 +428,7 @@ public class KafkaClusterTest {
     }
 
     @Test
-    public void kafkaClusterZookeeperModeSSL_ClientNoAuth() throws Exception {
+    void kafkaClusterZookeeperModeSSL_ClientNoAuth() throws Exception {
         try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
                 .testInfo(testInfo)
                 .brokerKeytoolCertificateGenerator(brokerKeytoolCertificateGenerator)
@@ -441,7 +441,7 @@ public class KafkaClusterTest {
     }
 
     @Test
-    public void kafkaClusterKraftModeSASL_SSL_ClientNoAuth() throws Exception {
+    void kafkaClusterKraftModeSASL_SSL_ClientNoAuth() throws Exception {
         try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
                 .testInfo(testInfo)
                 .brokerKeytoolCertificateGenerator(brokerKeytoolCertificateGenerator)
@@ -456,7 +456,7 @@ public class KafkaClusterTest {
     }
 
     @Test
-    public void kafkaClusterZookeeperModeSASL_SSL_ClientNoAuth() throws Exception {
+    void kafkaClusterZookeeperModeSASL_SSL_ClientNoAuth() throws Exception {
         try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
                 .testInfo(testInfo)
                 .brokerKeytoolCertificateGenerator(brokerKeytoolCertificateGenerator)

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/KafkaClusterTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/KafkaClusterTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -43,10 +44,12 @@ import io.kroxylicious.testing.kafka.clients.CloseableAdmin;
 import io.kroxylicious.testing.kafka.clients.CloseableConsumer;
 import io.kroxylicious.testing.kafka.clients.CloseableProducer;
 import io.kroxylicious.testing.kafka.common.KafkaClusterConfig;
+import io.kroxylicious.testing.kafka.common.KafkaClusterExecutionMode;
 import io.kroxylicious.testing.kafka.common.KafkaClusterFactory;
 import io.kroxylicious.testing.kafka.common.KeytoolCertificateGenerator;
 import io.kroxylicious.testing.kafka.common.Utils;
 
+import static io.kroxylicious.testing.kafka.common.KafkaClusterFactory.TEST_CLUSTER_EXECUTION_MODE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -75,6 +78,7 @@ class KafkaClusterTest {
     }
 
     @Test
+    @EnabledIf(value = "canTestAdditionalControllers", disabledReason = "Test can only pass in IN_VM execution mode")
     void kafkaClusterKraftModeWithMultipleControllers() throws Exception {
         try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
                 .testInfo(testInfo)
@@ -84,6 +88,13 @@ class KafkaClusterTest {
             cluster.start();
             verifyRecordRoundTrip(1, cluster);
         }
+    }
+
+    @SuppressWarnings("unused") // it is used via reflection by junit
+    public static boolean canTestAdditionalControllers() {
+        final KafkaClusterExecutionMode kafkaClusterExecutionMode = KafkaClusterExecutionMode.convertClusterExecutionMode(
+                System.getenv().get(TEST_CLUSTER_EXECUTION_MODE), KafkaClusterExecutionMode.IN_VM);
+        return KafkaClusterExecutionMode.CONTAINER != kafkaClusterExecutionMode;
     }
 
     @Test

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/KafkaClusterTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/KafkaClusterTest.java
@@ -31,6 +31,7 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -54,6 +55,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * Test case that simply exercises the ability to control the kafka cluster from the test.
  */
+@Timeout(value = 1, unit = TimeUnit.MINUTES)
 class KafkaClusterTest {
 
     private static final System.Logger LOGGER = System.getLogger(KafkaClusterTest.class.getName());
@@ -66,6 +68,18 @@ class KafkaClusterTest {
         try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
                 .testInfo(testInfo)
                 .kraftMode(true)
+                .build())) {
+            cluster.start();
+            verifyRecordRoundTrip(1, cluster);
+        }
+    }
+
+    @Test
+    void kafkaClusterKraftModeWithMultipleControllers() throws Exception {
+        try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
+                .testInfo(testInfo)
+                .kraftMode(true)
+                .kraftControllers(3)
                 .build())) {
             cluster.start();
             verifyRecordRoundTrip(1, cluster);

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/KafkaClusterTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/KafkaClusterTest.java
@@ -55,7 +55,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 /**
  * Test case that simply exercises the ability to control the kafka cluster from the test.
  */
-@Timeout(value = 1, unit = TimeUnit.MINUTES)
+@Timeout(value = 2, unit = TimeUnit.MINUTES)
 class KafkaClusterTest {
 
     private static final System.Logger LOGGER = System.getLogger(KafkaClusterTest.class.getName());

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfigTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfigTest.java
@@ -39,11 +39,59 @@ class KafkaClusterConfigTest {
         final var config = kafkaClusterConfig.generateConfigForSpecificNode(endpointConfig, 0);
 
         // Then
-        assertThat(config.getBrokerNum()).isEqualTo(0);
+        assertThat(config.getBrokerNum()).isZero();
         assertThat(config.getAnonPort()).isEqualTo(ANON_BASE_PORT);
         assertThat(config.getExternalPort()).isEqualTo(CLIENT_BASE_PORT);
         assertThat(config.getEndpoint()).isEqualTo("localhost:" + CLIENT_BASE_PORT);
         assertThat(config.getProperties()).containsEntry("node.id", "0");
+    }
+
+    @Test
+    void shouldConfigureMultipleControllersInCombinedMode() {
+        //Given
+        var numBrokers = 3;
+        final KafkaClusterConfig kafkaClusterConfig = kafkaClusterConfigBuilder.kraftMode(true).kraftControllers(3).brokersNum(numBrokers).build();
+
+        //When
+        for (int nodeId = 0; nodeId < numBrokers; nodeId++) {
+            assertNodeIdHasRole(kafkaClusterConfig, nodeId, "broker,controller");
+        }
+    }
+
+    @Test
+    void shouldConfigureMultipleControllersInControllerOnlyMode() {
+        //Given
+        var numBrokers = 1;
+        var numControllers = 3;
+        final KafkaClusterConfig kafkaClusterConfig = kafkaClusterConfigBuilder.kraftMode(true).kraftControllers(numControllers).brokersNum(numBrokers).build();
+
+        //When
+        assertNodeIdHasRole(kafkaClusterConfig, 0, "broker,controller");
+
+        for (int nodeId = 1; nodeId < numControllers; nodeId++) {
+            assertNodeIdHasRole(kafkaClusterConfig, nodeId, "controller");
+        }
+    }
+
+    @Test
+    void shouldConfigureSingleControllersInCombinedMode() {
+        //Given
+        var numBrokers = 3;
+        var numControllers = 1;
+        final KafkaClusterConfig kafkaClusterConfig = kafkaClusterConfigBuilder.kraftMode(true).kraftControllers(numControllers).brokersNum(numBrokers).build();
+
+        //When
+        assertNodeIdHasRole(kafkaClusterConfig, 0, "broker,controller");
+
+        for (int nodeId = 1; nodeId < numBrokers; nodeId++) {
+            assertNodeIdHasRole(kafkaClusterConfig, nodeId, "broker");
+        }
+    }
+
+    private void assertNodeIdHasRole(KafkaClusterConfig kafkaClusterConfig, int nodeId, String expectedRole) {
+        final var config = kafkaClusterConfig.generateConfigForSpecificNode(endpointConfig, nodeId);
+        assertThat(config.getProperties()).extracting(brokerConfig -> brokerConfig.get("process.roles")).as("nodeId: %s to have process.roles", nodeId).isEqualTo(
+                expectedRole);
     }
 
     static class EndpointConfig implements KafkaClusterConfig.KafkaEndpoints {

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/common/KafkaClusterFactoryTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/common/KafkaClusterFactoryTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.testing.kafka.common;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+class KafkaClusterFactoryTest {
+
+    @SuppressWarnings("resource")
+    @Test
+    void shouldThrowInContainerModeWithControllerOnlyNodes() {
+        // Due to https://github.com/ozangunalp/kafka-native/issues/88 we can't support controller only nodes, so we need to fail fast
+        // Given
+        final KafkaClusterConfig kafkaClusterConfig = KafkaClusterConfig.builder()
+                .execMode(KafkaClusterExecutionMode.CONTAINER)
+                .kraftMode(true)
+                .brokersNum(1)
+                .kraftControllers(2)
+                .build();
+
+        // When
+        assertThrows(IllegalStateException.class, () -> KafkaClusterFactory.create(kafkaClusterConfig));
+    }
+
+    @Test
+    void shouldCreateInstanceInVMModeWithControllerOnlyNodes() {
+        // Given
+        final KafkaClusterConfig kafkaClusterConfig = KafkaClusterConfig.builder()
+                .execMode(KafkaClusterExecutionMode.IN_VM)
+                .kraftMode(true)
+                .brokersNum(1)
+                .kraftControllers(2)
+                .build();
+
+        // When
+        try (var kafkaCluster = KafkaClusterFactory.create(kafkaClusterConfig)) {
+            assertThat(kafkaCluster).isNotNull();
+        }
+        catch (Exception e) {
+            fail("Failed to create KafkaCluster: " + e.getMessage(), e);
+        }
+    }
+
+    @Test
+    void shouldCreateInstanceInContainerModeWithoutControllerOnlyNodes() {
+        // Given
+        final KafkaClusterConfig kafkaClusterConfig = KafkaClusterConfig.builder()
+                .execMode(KafkaClusterExecutionMode.IN_VM).kraftMode(true)
+                .brokersNum(3).kraftControllers(2).build();
+
+        // When
+        try (var kafkaCluster = KafkaClusterFactory.create(kafkaClusterConfig)) {
+            assertThat(kafkaCluster).isNotNull();
+        }
+        catch (Exception e) {
+            fail("Failed to create KafkaCluster: " + e.getMessage(), e);
+        }
+    }
+
+}

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaClusterTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaClusterTest.java
@@ -1,0 +1,32 @@
+package io.kroxylicious.testing.kafka.testcontainers;
+
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+import org.junit.jupiter.api.Test;
+
+import io.kroxylicious.testing.kafka.common.KafkaClusterConfig;
+import io.kroxylicious.testing.kafka.common.KafkaClusterExecutionMode;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TestcontainersKafkaClusterTest {
+
+    @SuppressWarnings("resource")
+    @Test
+    void shouldThrowInContainerModeWithControllerOnlyNodes() {
+        // Due to https://github.com/ozangunalp/kafka-native/issues/88 we can't support controller only nodes, so we need to fail fast
+        // Given
+        final KafkaClusterConfig kafkaClusterConfig = KafkaClusterConfig.builder()
+                .execMode(KafkaClusterExecutionMode.CONTAINER)
+                .kraftMode(true)
+                .brokersNum(1)
+                .kraftControllers(2)
+                .build();
+
+        // When
+        assertThrows(IllegalStateException.class, () -> new TestcontainersKafkaCluster(kafkaClusterConfig));
+    }
+}

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaClusterTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaClusterTest.java
@@ -1,10 +1,11 @@
-package io.kroxylicious.testing.kafka.testcontainers;
-
 /*
  * Copyright Kroxylicious Authors.
  *
  * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
+
+package io.kroxylicious.testing.kafka.testcontainers;
+
 import org.junit.jupiter.api.Test;
 
 import io.kroxylicious.testing.kafka.common.KafkaClusterConfig;

--- a/impl/src/test/resources/log4j2-test.properties
+++ b/impl/src/test/resources/log4j2-test.properties
@@ -19,7 +19,7 @@ status = info
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c:%L - %m%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %t %c:%L - %m%n
 
 filter.threshold.type = ThresholdFilter
 filter.threshold.level = debug

--- a/integration-test/src/test/java/io/kroxylicious/testing/kafka/junit5ext/MultipleNodesIntegrationTest.java
+++ b/integration-test/src/test/java/io/kroxylicious/testing/kafka/junit5ext/MultipleNodesIntegrationTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.testing.kafka.junit5ext;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.DescribeClusterResult;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import io.kroxylicious.testing.kafka.common.KRaftCluster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
+
+@ExtendWith(KafkaClusterExtension.class)
+class MultipleNodesIntegrationTest {
+
+    @Test
+    void shouldInjectClusterWithMultipleBrokers(@KRaftCluster(numControllers = 3) KafkaCluster cluster) {
+        try (Admin admin = Admin.create(cluster.getKafkaClientConfiguration())) {
+            // When
+            final DescribeClusterResult describeClusterResult = admin.describeCluster();
+
+            // Then
+            await().atMost(30, TimeUnit.SECONDS).until(() -> describeClusterResult.nodes().isDone());
+            assertThat(describeClusterResult.nodes()).isNotCancelled();
+            assertThat(describeClusterResult.controller()).isNotCancelled();
+        }
+    }
+}

--- a/junit5-extension/pom.xml
+++ b/junit5-extension/pom.xml
@@ -23,7 +23,7 @@
 
     <name>Kroxylicious Testing JUnit5 extension</name>
     <description>
-    Provides a JUNit5 extension for providing KafkaCluster implementations to tests and running tests over multiple cluster configurations.
+    Provides a JUnit5 extension for providing KafkaCluster implementations to tests and running tests over multiple cluster configurations.
     </description>
 
     <dependencies>


### PR DESCRIPTION
### Type of change

- Bugfix
- Enhancement 

### Description

Fixes the cluster configuration and start up so that multiple controller nodes work. Fixes: https://github.com/kroxylicious/kroxylicious-junit5-extension/issues/165

### Additional Context

I still see this as an intermediate step, there are kludges to detect if a node should be a controller or a broker or both. While they work it feels like we are missing a proper object model that knows what role a node has. We also lack the ability for users to control the cluster topology (i.e. they can't have nodes in controller only mode with while they they still have brokers to start)

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
