### PR TITLE
Update kafka version range in testVersions to include 3.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please enumerate all user-facing changes using format `<githib issue/pr number>:
 
 ## 1.0.0
 
+## 0.6.0
+
+* [#180](https://github.com/kroxylicious/kroxylicious-junit5-extension/pull/180): Update kafka version range in testVersions to include 3.5.1
+
 ## 0.5.0
 
 * [#146](https://github.com/kroxylicious/kroxylicious-junit5-extension/pull/146): Expose TestInfo (and thus DisplayName) when clusters are injected via  annotations.

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/TemplateTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/TemplateTest.java
@@ -159,6 +159,7 @@ public class TemplateTest {
     private static Stream<Version> versions() {
         return Stream.of(
                 version("latest"),
+                version("3.5.1"),
                 version("3.4.0"),
                 version("3.2.3"),
                 version("3.1.2"));
@@ -180,6 +181,7 @@ public class TemplateTest {
             assertEquals(Set.of("latest-kafka-3.1.2",
                     "latest-kafka-3.2.3",
                     "latest-kafka-3.4.0",
+                    "latest-kafka-3.5.1",
                     "latest"), observedVersions);
         }
     }


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

`kafka-native` has just published Kafka 3.5.1.  The Junit extension starts to use this by default, however, the enumeration of versions tested by testVersions should be extended.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
