### PR TITLE
fix: stop Utils#createTopic trying to create topic if admin client gets closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Please enumerate all user-facing changes using format `<githib issue/pr number>:
 
 ## 0.6.0
 
+* [#182](https://github.com/kroxylicious/kroxylicious-junit5-extension/issues/182): Prevent possibility of loop when performing consistency test (workaround KAFKA-15507)
 * [#180](https://github.com/kroxylicious/kroxylicious-junit5-extension/pull/180): Update kafka version range in testVersions to include 3.5.1
 
 ## 0.5.0

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/Utils.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/Utils.java
@@ -227,7 +227,10 @@ public class Utils {
         // If the throwable originates from within a CompletionStage's handler, it will be wrapped within a
         // CompletionException.
         var throwable = potentiallyWrapped instanceof CompletionException && potentiallyWrapped.getCause() != null ? potentiallyWrapped.getCause() : potentiallyWrapped;
-        return throwable instanceof RetriableException || throwable instanceof InvalidReplicationFactorException
+        boolean retriable = throwable instanceof RetriableException
+                && (throwable.getMessage() == null
+                        || !throwable.getMessage().contains("The AdminClient is not accepting new calls") /* workaround for KAFKA-15507 */ );
+        return retriable || throwable instanceof InvalidReplicationFactorException
                 || (throwable instanceof TopicExistsException && throwable.getMessage().contains("is marked for deletion"));
     }
 


### PR DESCRIPTION
### Type of change


- Bugfix

### Description

Break out of the createTopic creation loop if the `RetriableException` message indicates that the Admin client is closed.  This prevents a thread pointlessly spinning in the background, failing forever.

_Please describe your pull request_

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
