### PR TITLE
Replace NPE with more useful(?) error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ Please enumerate all user-facing changes using format `<githib issue/pr number>:
 
 ## 1.0.0
 
+
+
 ## 0.6.0
 
+* [#186](https://github.com/kroxylicious/kroxylicious-junit5-extension/pull/186): Replace a Null Pointer Exception with a more meaningful one when there is no existing cluster
 * [#182](https://github.com/kroxylicious/kroxylicious-junit5-extension/issues/182): Prevent possibility of loop when performing consistency test (workaround KAFKA-15507)
 * [#180](https://github.com/kroxylicious/kroxylicious-junit5-extension/pull/180): Update kafka version range in testVersions to include 3.5.1
 

--- a/junit5-extension/src/main/java/io/kroxylicious/testing/kafka/junit5ext/KafkaClusterExtension.java
+++ b/junit5-extension/src/main/java/io/kroxylicious/testing/kafka/junit5ext/KafkaClusterExtension.java
@@ -5,28 +5,10 @@
  */
 package io.kroxylicious.testing.kafka.junit5ext;
 
-import java.lang.annotation.Annotation;
-import java.lang.reflect.AnnotatedElement;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.lang.reflect.Parameter;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.nio.ByteBuffer;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Base64;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Objects;
-import java.util.ServiceLoader;
-import java.util.UUID;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
+import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import io.kroxylicious.testing.kafka.api.KafkaClusterConstraint;
+import io.kroxylicious.testing.kafka.api.KafkaClusterProvisioningStrategy;
+import io.kroxylicious.testing.kafka.api.KroxyliciousTestInfo;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -75,10 +57,27 @@ import org.junit.platform.commons.support.HierarchyTraversalMode;
 import org.junit.platform.commons.util.ExceptionUtils;
 import org.junit.platform.commons.util.ReflectionUtils;
 
-import io.kroxylicious.testing.kafka.api.KafkaCluster;
-import io.kroxylicious.testing.kafka.api.KafkaClusterConstraint;
-import io.kroxylicious.testing.kafka.api.KafkaClusterProvisioningStrategy;
-import io.kroxylicious.testing.kafka.api.KroxyliciousTestInfo;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+import java.util.ServiceLoader;
+import java.util.UUID;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static java.lang.System.Logger.Level.TRACE;
 import static org.junit.platform.commons.support.ReflectionSupport.findFields;
@@ -756,7 +755,7 @@ public class KafkaClusterExtension implements
         }
         else {
             clusterName = findLastUsedClusterId(store, uuidsFrom(STARTING_PREFIX));
-            if (!clusterName.equals(STARTING_PREFIX)) {
+            if (clusterName == null || !clusterName.equals(STARTING_PREFIX)) {
                 throw new AmbiguousKafkaClusterException(
                         "KafkaCluster to associate with " + description + " is ambiguous, " +
                                 "use @Name on the intended cluster and this element to disambiguate");


### PR DESCRIPTION
Signed-off-by: Sam Barker <sbarker@redhat.com>

### Type of change

_Select the type of your PR_

- Bugfix

### Description

Fixes an NPE when the the last cluster is not found. By definintion null doesn't match the prefix so through the same exception.

### Additional Context

A test I was writing using the extension failed with the following NPE
```

java.lang.NullPointerException: Cannot invoke "String.equals(Object)" because "clusterName" is null

	at io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension.findClusterFromContext(KafkaClusterExtension.java:761)
	at io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension.getAdmin(KafkaClusterExtension.java:856)
	at io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension.lambda$injectFields$8(KafkaClusterExtension.java:564)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.Collections$UnmodifiableCollection.forEach(Collections.java:1092)
	at io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension.injectFields(KafkaClusterExtension.java:562)
	at io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension.injectInstanceFields(KafkaClusterExtension.java:534)
	at io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension.lambda$beforeEach$4(KafkaClusterExtension.java:530)
	at java.base/java.util.Collections$SingletonList.forEach(Collections.java:4968)
	at io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension.beforeEach(KafkaClusterExtension.java:530)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	Suppressed: java.lang.NullPointerException: Cannot invoke "java.util.Set.forEach(java.util.function.Consumer)" because the return value of "org.junit.jupiter.api.extension.ExtensionContext$Store.remove(Object, 
java.lang.Class)" is null
		at org.mockito.junit.jupiter.MockitoExtension.afterEach(MockitoExtension.java:184)
		... 2 more
```

I think the test is failing for other reaons but they get obscured by this NPE (and maybe by the replacement exception too)

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
