### PR TITLE
Reduce the scope of fields the extension will inject into.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Please enumerate all user-facing changes using format `<githib issue/pr number>:
 
 ## 0.6.0
 
+* [#187](https://github.com/kroxylicious/kroxylicious-junit5-extension/pull/187): Tighten the conditions under which the extension will inject values.
 * [#186](https://github.com/kroxylicious/kroxylicious-junit5-extension/pull/186): Replace a Null Pointer Exception with a more meaningful one when there is no existing cluster
 * [#182](https://github.com/kroxylicious/kroxylicious-junit5-extension/issues/182): Prevent possibility of loop when performing consistency test (workaround KAFKA-15507)
 * [#180](https://github.com/kroxylicious/kroxylicious-junit5-extension/pull/180): Update kafka version range in testVersions to include 3.5.1

--- a/README.md
+++ b/README.md
@@ -105,6 +105,23 @@ In case you use podman for testcontainers, some tips must be taken into account:
 
 ---
 
+## Field injection and Parameter Resolution
+
+The extension supports injecting clusters and clients:
+- into fields of the test class 
+- as parameters to `@BeforeAll`
+- as parameters to `@BeforeEach`
+- as parameters to test methods
+
+To avoid collisions with other extensions, such as Mockito, we will only inject into fields which:
+- have no annotations  
+OR are annotated with annotations from the following packages
+- `io.kroxylicious`
+- `org.junit`
+- `java.lang`
+
+The extension will not try to overwrite fields which have already been initialised. 
+
 ## Template tests
 
 You can also use test templates to execute the same test over a number of different cluster configurations. Here's an example:

--- a/junit5-extension/src/main/java/io/kroxylicious/testing/kafka/junit5ext/KafkaClusterExtension.java
+++ b/junit5-extension/src/main/java/io/kroxylicious/testing/kafka/junit5ext/KafkaClusterExtension.java
@@ -610,7 +610,7 @@ public class KafkaClusterExtension implements
                 .flatMap(List::stream)
                 .filter(field -> {
                     try {
-                        return field.get(testInstance) == null;
+                        return makeAccessible(field).get(testInstance) == null;
                     }
                     catch (IllegalAccessException e) {
                         ExceptionUtils.throwAsUncheckedException(e);

--- a/junit5-extension/src/main/java/io/kroxylicious/testing/kafka/junit5ext/KafkaClusterExtension.java
+++ b/junit5-extension/src/main/java/io/kroxylicious/testing/kafka/junit5ext/KafkaClusterExtension.java
@@ -109,7 +109,7 @@ import static org.junit.platform.commons.util.ReflectionUtils.makeAccessible;
  *         producer.send(new ProducerRecord<>("hello", "world")).get();
  *     }
  * }
- * }**</pre>
+ * }</pre>
  *
  * <p>Notes:</p>
  * <ol>
@@ -121,6 +121,22 @@ import static org.junit.platform.commons.util.ReflectionUtils.makeAccessible;
  * <li>Your test methods can declare {@code Producer}, {@code Consumer} and {@code Admin}-typed parameters.
  * They will be configured to bootstrap against the {@code cluster}.</li>
  * </ol>
+ *
+ * <p>The extension supports injecting clusters and clients:</p>
+ * <ul>
+ *     <li>into fields of the test class</li>
+ *     <li>as parameters to {@code  @BeforeAll}</li>
+ *     <li>as parameters to {@code @BeforeEach}</li>
+ *     <li>as parameters to test methods</li>
+ * </ul>
+ * To avoid collisions with other extensions, such as Mockito, we will only inject into fields which:
+ *  <ul>
+ *      <li> have no annotations</li>
+ *      <li style="list-style: none">OR are annotated with annotations from the following packages</li>
+ *      <li>{@code java.lang}</li>
+ *      <li>{@code org.junit}</li>
+ *      <li>{@code io.kroxylicious}</li>
+ * </ul>
  */
 public class KafkaClusterExtension implements
         ParameterResolver, BeforeEachCallback,

--- a/junit5-extension/src/main/java/io/kroxylicious/testing/kafka/junit5ext/KafkaClusterExtension.java
+++ b/junit5-extension/src/main/java/io/kroxylicious/testing/kafka/junit5ext/KafkaClusterExtension.java
@@ -89,7 +89,7 @@ import static org.junit.platform.commons.util.ReflectionUtils.makeAccessible;
  * A JUnit 5 extension that allows declarative injection of a {@link KafkaCluster} into a test
  * via static or instance field(s) and/or parameters.
  *
- * <p>A simple example looks like:</p>
+ * <h2>A simple example looks like:</h2>
  * <pre>{@code
  * import io.kroxylicious.junit5.KafkaClusterExtension;
  * import org.apache.kafka.clients.producer.Producer;
@@ -111,7 +111,7 @@ import static org.junit.platform.commons.util.ReflectionUtils.makeAccessible;
  * }
  * }</pre>
  *
- * <p>Notes:</p>
+ * <h3>Notes:</h3>
  * <ol>
  * <li>You have to tell Junit that you're using the extension using {@code @ExtendWith}.</li>
  * <li>An instance field of type {@link KafkaCluster} will cause a new cluster to be provisioned for
@@ -122,6 +122,7 @@ import static org.junit.platform.commons.util.ReflectionUtils.makeAccessible;
  * They will be configured to bootstrap against the {@code cluster}.</li>
  * </ol>
  *
+ * <h2>Injection rules</h2>
  * <p>The extension supports injecting clusters and clients:</p>
  * <ul>
  *     <li>into fields of the test class</li>

--- a/junit5-extension/src/main/java/io/kroxylicious/testing/kafka/junit5ext/KafkaClusterExtension.java
+++ b/junit5-extension/src/main/java/io/kroxylicious/testing/kafka/junit5ext/KafkaClusterExtension.java
@@ -594,7 +594,7 @@ public class KafkaClusterExtension implements
                 .flatMap(List::stream)
                 .filter(field -> {
                     try {
-                        return makeAccessible(field).get(testInstance) == null;
+                        return field.get(testInstance) == null;
                     }
                     catch (IllegalAccessException e) {
                         ExceptionUtils.throwAsUncheckedException(e);
@@ -603,7 +603,7 @@ public class KafkaClusterExtension implements
                 })
                 .forEach(field -> {
                     try {
-                        field.set(testInstance,
+                        makeAccessible(field).set(testInstance,
                                 clientFactory.getClient(
                                         "field " + field.getName(),
                                         field,

--- a/junit5-extension/src/main/java/io/kroxylicious/testing/kafka/junit5ext/KafkaClusterExtension.java
+++ b/junit5-extension/src/main/java/io/kroxylicious/testing/kafka/junit5ext/KafkaClusterExtension.java
@@ -540,6 +540,7 @@ public class KafkaClusterExtension implements
             final String canonicalName = annotation.annotationType().getCanonicalName();
             if (!canonicalName.startsWith("io.kroxylicious") && !canonicalName.startsWith("org.junit")) {
                 supported = false;
+                break;
             }
         }
         return supported;

--- a/junit5-extension/src/test/java/com/example/RuntimeMarkerAnnotation.java
+++ b/junit5-extension/src/test/java/com/example/RuntimeMarkerAnnotation.java
@@ -12,5 +12,5 @@ import java.lang.annotation.Target;
 
 @Target({ ElementType.FIELD, ElementType.METHOD, ElementType.TYPE })
 @Retention(RetentionPolicy.RUNTIME)
-public @interface StubAnnotation {
+public @interface RuntimeMarkerAnnotation {
 }

--- a/junit5-extension/src/test/java/com/example/StubAnnotation.java
+++ b/junit5-extension/src/test/java/com/example/StubAnnotation.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package com.example;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.FIELD, ElementType.METHOD, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface StubAnnotation {
+}

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/InstanceFieldExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/InstanceFieldExtensionTest.java
@@ -44,7 +44,7 @@ class InstanceFieldExtensionTest extends AbstractExtensionTest {
     @Order(1)
     Producer<String, String> fieldWithOrderAnnotation;
 
-    final MockConsumer<String, String> mockConsumer = new MockConsumer(OffsetResetStrategy.LATEST);
+    final MockConsumer<String, String> mockConsumer = new MockConsumer<>(OffsetResetStrategy.LATEST);
 
     @StubAnnotation
     Admin fieldWithUnrecognizedAnnotation;

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/InstanceFieldExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/InstanceFieldExtensionTest.java
@@ -91,7 +91,7 @@ class InstanceFieldExtensionTest extends AbstractExtensionTest {
 
     @Test
     void fieldWithUnrecognizedAnnotationsNotInjected() {
-        assertNull(fieldWithUnrecognizedAnnotation);
+        assertThat(fieldWithUnrecognizedAnnotation).isNull();
     }
 
     @Test

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/InstanceFieldExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/InstanceFieldExtensionTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import com.example.StubAnnotation;
+import com.example.RuntimeMarkerAnnotation;
 
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.common.BrokerCluster;
@@ -46,7 +46,7 @@ class InstanceFieldExtensionTest extends AbstractExtensionTest {
 
     final MockConsumer<String, String> mockConsumer = new MockConsumer<>(OffsetResetStrategy.LATEST);
 
-    @StubAnnotation
+    @RuntimeMarkerAnnotation
     Admin fieldWithUnrecognizedAnnotation;
 
     @SuppressWarnings("DeprecatedIsStillUsed")

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/InstanceFieldExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/InstanceFieldExtensionTest.java
@@ -5,8 +5,10 @@
  */
 package io.kroxylicious.testing.kafka.junit5ext;
 
-import java.util.concurrent.ExecutionException;
-
+import com.example.RuntimeMarkerAnnotation;
+import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import io.kroxylicious.testing.kafka.common.BrokerCluster;
+import io.kroxylicious.testing.kafka.invm.InVMKafkaCluster;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.MockConsumer;
@@ -16,11 +18,7 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import com.example.RuntimeMarkerAnnotation;
-
-import io.kroxylicious.testing.kafka.api.KafkaCluster;
-import io.kroxylicious.testing.kafka.common.BrokerCluster;
-import io.kroxylicious.testing.kafka.invm.InVMKafkaCluster;
+import java.util.concurrent.ExecutionException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -32,7 +30,7 @@ class InstanceFieldExtensionTest extends AbstractExtensionTest {
     KafkaCluster instanceCluster;
 
     @BrokerCluster(numBrokers = 1)
-    @Name("kafkaCLuster")
+    @Name("kafkaCluster")
     KafkaCluster namedCluster;
 
     Consumer<String, String> injectedConsumer;
@@ -53,7 +51,7 @@ class InstanceFieldExtensionTest extends AbstractExtensionTest {
     @Deprecated
     Admin fieldWithJavaLangAnnotations;
 
-    @Name("kafkaCLuster")
+    @Name("kafkaCluster")
     Admin namedAdmin;
 
     @Test

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/InstanceFieldExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/InstanceFieldExtensionTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.util.concurrent.ExecutionException;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 @ExtendWith(KafkaClusterExtension.class)
 class InstanceFieldExtensionTest extends AbstractExtensionTest {

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/InstanceFieldExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/InstanceFieldExtensionTest.java
@@ -8,24 +8,94 @@ package io.kroxylicious.testing.kafka.junit5ext;
 import java.util.concurrent.ExecutionException;
 
 import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.clients.producer.Producer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import com.example.StubAnnotation;
 
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.common.BrokerCluster;
 import io.kroxylicious.testing.kafka.invm.InVMKafkaCluster;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(KafkaClusterExtension.class)
-public class InstanceFieldExtensionTest extends AbstractExtensionTest {
+class InstanceFieldExtensionTest extends AbstractExtensionTest {
 
     @BrokerCluster(numBrokers = 1)
     KafkaCluster instanceCluster;
 
+    @BrokerCluster(numBrokers = 1)
+    @Name("kafkaCLuster")
+    KafkaCluster namedCluster;
+
+    Consumer<String, String> injectedConsumer;
+
+    Admin injectedAdmin;
+
+    Producer<String, String> injectedProducer;
+
+    @Order(1)
+    Producer<String, String> fieldWithOrderAnnotation;
+
+    final MockConsumer<String, String> mockConsumer = new MockConsumer(OffsetResetStrategy.LATEST);
+
+    @StubAnnotation
+    Admin fieldWithUnrecognizedAnnotation;
+
+    @SuppressWarnings("DeprecatedIsStillUsed")
+    @Deprecated
+    Admin fieldWithJavaLangAnnotations;
+
+    @Name("kafkaCLuster")
+    Admin namedAdmin;
+
     @Test
-    public void clusterInstanceField()
+    void shouldInjectConsumerField() {
+        assertThat(injectedConsumer).isNotNull().isInstanceOf(Consumer.class);
+    }
+
+    @Test
+    void shouldInjectProducerField() {
+        assertThat(injectedProducer).isNotNull().isInstanceOf(Producer.class);
+    }
+
+    @Test
+    void shouldInjectAdminField() {
+        assertThat(injectedAdmin).isNotNull().isInstanceOf(Admin.class);
+    }
+
+    @Test
+    void shouldNotInjectIntoInitialisedField() {
+        assertThat(mockConsumer).isNotNull().isInstanceOf(MockConsumer.class);
+    }
+
+    @Test
+    void shouldInjectIntoFieldsWithRecognisedAnnotation() {
+        assertThat(fieldWithOrderAnnotation).isNotNull().isInstanceOf(Producer.class);
+        assertThat(fieldWithJavaLangAnnotations).isNotNull().isInstanceOf(Admin.class);
+        assertThat(namedAdmin).isNotNull().isInstanceOf(Admin.class);
+    }
+
+    @Test
+    void shouldInjectIntoFieldWithJunitAnnotation() {
+        assertThat(fieldWithOrderAnnotation).isNotNull().isInstanceOf(Producer.class);
+        // TODO should we use the producer to send a record?
+    }
+
+    @Test
+    void fieldWithUnrecognizedAnnotationsNotInjected() {
+        assertNull(fieldWithUnrecognizedAnnotation);
+    }
+
+    @Test
+    void clusterInstanceField()
             throws ExecutionException, InterruptedException {
         var dc = describeCluster(instanceCluster.getKafkaClientConfiguration());
         assertEquals(1, dc.nodes().get().size());
@@ -34,7 +104,7 @@ public class InstanceFieldExtensionTest extends AbstractExtensionTest {
     }
 
     @Test
-    public void adminParameter(Admin admin) throws ExecutionException, InterruptedException {
+    void adminParameter(Admin admin) throws ExecutionException, InterruptedException {
         assertSameCluster(instanceCluster, admin);
     }
 }

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/InstanceFieldExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/InstanceFieldExtensionTest.java
@@ -37,6 +37,8 @@ class InstanceFieldExtensionTest extends AbstractExtensionTest {
 
     Admin injectedAdmin;
 
+    private Admin privateField;
+
     Producer<String, String> injectedProducer;
 
     @Order(1)
@@ -67,6 +69,11 @@ class InstanceFieldExtensionTest extends AbstractExtensionTest {
     @Test
     void shouldInjectAdminField() {
         assertThat(injectedAdmin).isNotNull().isInstanceOf(Admin.class);
+    }
+
+    @Test
+    void shouldInjectIntoPrivateField() {
+        assertThat(privateField).isNotNull().isInstanceOf(Admin.class);
     }
 
     @Test

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/StaticFieldExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/StaticFieldExtensionTest.java
@@ -5,9 +5,8 @@
  */
 package io.kroxylicious.testing.kafka.junit5ext;
 
-import io.kroxylicious.testing.kafka.api.KafkaCluster;
-import io.kroxylicious.testing.kafka.common.BrokerCluster;
-import io.kroxylicious.testing.kafka.invm.InVMKafkaCluster;
+import java.util.concurrent.ExecutionException;
+
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.KafkaAdminClient;
@@ -19,7 +18,9 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.util.concurrent.ExecutionException;
+import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import io.kroxylicious.testing.kafka.common.BrokerCluster;
+import io.kroxylicious.testing.kafka.invm.InVMKafkaCluster;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/StaticFieldExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/StaticFieldExtensionTest.java
@@ -26,7 +26,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 @ExtendWith(KafkaClusterExtension.class)
-public class StaticFieldExtensionTest extends AbstractExtensionTest {
+class StaticFieldExtensionTest extends AbstractExtensionTest {
 
     @Order(1)
     @BrokerCluster(numBrokers = 1)
@@ -39,7 +39,7 @@ public class StaticFieldExtensionTest extends AbstractExtensionTest {
     static AdminClient staticAdminClient;
 
     @Test
-    public void testKafkaClusterStaticField()
+    void testKafkaClusterStaticField()
             throws ExecutionException, InterruptedException {
         var dc = describeCluster(staticCluster.getKafkaClientConfiguration());
         assertEquals(1, dc.nodes().get().size());
@@ -48,47 +48,47 @@ public class StaticFieldExtensionTest extends AbstractExtensionTest {
     }
 
     @Test
-    public void adminStaticField() throws ExecutionException, InterruptedException {
+    void adminStaticField() throws ExecutionException, InterruptedException {
         assertSameCluster(staticCluster, staticAdmin);
     }
 
     @Test
-    public void adminClientStaticField() throws ExecutionException, InterruptedException {
+    void adminClientStaticField() throws ExecutionException, InterruptedException {
         assertSameCluster(staticCluster, staticAdminClient);
     }
 
     @Test
-    public void adminParameter(Admin admin) throws ExecutionException, InterruptedException {
+    void adminParameter(Admin admin) throws ExecutionException, InterruptedException {
         assertSameCluster(staticCluster, admin);
     }
 
     @Test
-    public void adminClientParameter(AdminClient admin) throws ExecutionException, InterruptedException {
+    void adminClientParameter(AdminClient admin) throws ExecutionException, InterruptedException {
         assertSameCluster(staticCluster, admin);
     }
 
     @Test
-    public void kafkaAdminClientParameter(KafkaAdminClient admin) throws ExecutionException, InterruptedException {
+    void kafkaAdminClientParameter(KafkaAdminClient admin) throws ExecutionException, InterruptedException {
         assertSameCluster(staticCluster, admin);
     }
 
     @Test
-    public void producerParameter(Producer<String, String> producer) throws ExecutionException, InterruptedException {
+    void producerParameter(Producer<String, String> producer) throws ExecutionException, InterruptedException {
         doProducer(producer, "hello", "world");
     }
 
     @Test
-    public void kafkaProducerParameter(KafkaProducer<String, String> producer) throws ExecutionException, InterruptedException {
+    void kafkaProducerParameter(KafkaProducer<String, String> producer) throws ExecutionException, InterruptedException {
         doProducer(producer, "hello", "world");
     }
 
     @Test
-    public void consumerParameter(Consumer<String, String> consumer) {
+    void consumerParameter(Consumer<String, String> consumer) {
         doConsumer(consumer);
     }
 
     @Test
-    public void kafkaConsumerParameter(KafkaConsumer<String, String> consumer) {
+    void kafkaConsumerParameter(KafkaConsumer<String, String> consumer) {
         doConsumer(consumer);
     }
 

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/StaticFieldExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/StaticFieldExtensionTest.java
@@ -5,8 +5,9 @@
  */
 package io.kroxylicious.testing.kafka.junit5ext;
 
-import java.util.concurrent.ExecutionException;
-
+import io.kroxylicious.testing.kafka.api.KafkaCluster;
+import io.kroxylicious.testing.kafka.common.BrokerCluster;
+import io.kroxylicious.testing.kafka.invm.InVMKafkaCluster;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.KafkaAdminClient;
@@ -18,9 +19,7 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import io.kroxylicious.testing.kafka.api.KafkaCluster;
-import io.kroxylicious.testing.kafka.common.BrokerCluster;
-import io.kroxylicious.testing.kafka.invm.InVMKafkaCluster;
+import java.util.concurrent.ExecutionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;

--- a/pom.xml
+++ b/pom.xml
@@ -495,6 +495,11 @@
                                 <goals>
                                     <goal>jar</goal>
                                 </goals>
+                                <configuration>
+                                    <links>
+                                        <link>https://junit.org/junit5/docs/${junit.version}/api/</link>
+                                    </links>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix


### Description

This change restricts the extension to only injecting into fields where there are no annotations, or only annotations known to be safe which are those coming from:
- `io.kroxylicious` 
- `org.junit`
- `java.lang`

It also prevents injection into fields which already have a non null value.

### Additional Context

I've had a couple of issues with the extension trying to inject into fields without having a KafkaCluster field and thus the injection fails. In my specific tests I didn't want the extension to inject into the fields. As I was using a mockito to mock the admin client or building my own `MockProducer` or `MockConsumer`. 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
