### PR TITLE
Fix #181: testVersions shouldn't assume the version of "latest"

### DIFF
--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/TemplateTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/TemplateTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.kafka.clients.admin.Admin;
@@ -158,7 +159,6 @@ public class TemplateTest {
 
     private static Stream<Version> versions() {
         return Stream.of(
-                version("latest"),
                 version("3.5.1"),
                 version("3.4.0"),
                 version("3.2.3"),
@@ -178,11 +178,7 @@ public class TemplateTest {
 
         @AfterAll
         public void afterAll() {
-            assertEquals(Set.of("latest-kafka-3.1.2",
-                    "latest-kafka-3.2.3",
-                    "latest-kafka-3.4.0",
-                    "latest-kafka-3.5.1",
-                    "latest"), observedVersions);
+            assertEquals(versions().map(Version::value).map("latest-kafka-%s"::formatted).collect(Collectors.toSet()), observedVersions);
         }
     }
 }


### PR DESCRIPTION

### Type of change

_Select the type of your PR_

- Bugfix

### Description

Ascribing a version number of the latest tag means that the tests fail as soon as the tag is moved to a newer kafka release.

### Additional Context

Test stablity.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
