### PR TITLE
Fix test failure under jdk 21 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,9 @@
         <annotations.version>24.0.1</annotations.version>
         <duct-tape.version>1.0.8</duct-tape.version>
         <mockito.version>5.6.0</mockito.version>
+
+        <!-- Required for JDK 21 compatibility, remove dependency management for byte-buddy once assertj bumps to a newer bytebuddy -->
+        <byte-buddy.version>1.14.9</byte-buddy.version>
         <!-- Avoids issues with ryuk when running with podman https://github.com/containers/podman/issues/7927#issuecomment-731525556 -->
         <testcontainers.ryuk.disabled>true</testcontainers.ryuk.disabled>
     </properties>
@@ -211,6 +214,12 @@
                 <version>${mockito.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy</artifactId>
+                <version>${byte-buddy.version}</version>
+                <scope>test</scope>
             </dependency>
 
         </dependencies>


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

If the developer is using JDK 21, the tests fail like this, even though the project itself targets JDK 17.

```
[ERROR]   LoggingPrintStreamTest.twoLogs » Mockito
Mockito cannot mock this class: interface java.lang.System$Logger.

If you're not sure why you're getting this error, please open an issue on GitHub.


Java               : 21
JVM vendor name    : Eclipse Adoptium
JVM vendor version : 21+35-LTS
JVM name           : OpenJDK 64-Bit Server VM
JVM version        : 21+35-LTS
JVM info           : mixed mode, sharing
OS name            : Mac OS X
OS version         : 13.6


You are seeing this disclaimer because Mockito is configured to create inlined mocks.
You can learn about inline mocks and their limitations under item #39 of the Mockito class javadoc.

Underlying exception : org.mockito.exceptions.base.MockitoException: Could not modify all classes [interface java.lang.System$Logger]
```

The fix is to provide a dependency override byte-buddy, until assertj makes a release compatible with JDK 21.  Compatibility with JDK 17 is not affected by this fix.


### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
