### PR TITLE
Fix #197: Consumer of the extension should be able to choose the version of the kafka dependency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ Please enumerate all user-facing changes using format `<githib issue/pr number>:
 ## 1.0.0
 
 
+## 0.7.0
+
+* [#197](https://github.com/kroxylicious/kroxylicious-junit5-extension/issues/197): Consumer of the extension should be able to choose the version of the kafka dependency.
+
+### Changes, deprecations and removals
+
+* It is now necessary to declare org.apache.kafka:kafka_2.13 as a test dependency.  If you wish to use kafka in-vm with zookeeper, org.apache.zookeeper:zookeeper
+  must be a test dependency too.
+
 
 ## 0.6.0
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,27 @@ testImplementation 'io.kroxylicious.testing:testing-junit5-extension:0.1'
 Maven
 
 ```xml
-<dependency>
-    <groupId>io.kroxylicious.testing</groupId>
-    <artifactId>testing-junit5-extension</artifactId>
-    <version>0.1</version>
-</dependency>
+<dependencies>
+    <dependency>
+        <groupId>io.kroxylicious.testing</groupId>
+        <artifactId>testing-junit5-extension</artifactId>
+        <version>0.1</version>
+    </dependency>
+    <!-- Kafka Broker version you want to use -->
+    <dependency>
+        <groupId>org.apache.kafka</groupId>
+        <artifactId>kafka_2.13</artifactId>
+        <version>${kafka.version}</version> <!-- versions 3.3.0 or higher is known to work -->
+        <scope>test</scope>
+    </dependency>
+    <!-- Optional, required if you want to use in-VM kafka in Zookeeper mode. -->
+    <dependency>
+        <groupId>org.apache.zookeeper</groupId>
+        <artifactId>zookeeper</artifactId>
+        <version>${zookeeper.version}</version> <!-- version 3.6.3 or higher is known to work -->
+        <scope>test</scope>
+    </dependency>
+</dependencies>
 ```
 
 ## Example

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -42,10 +42,6 @@
             <artifactId>kafka_2.13</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka-server-common</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
         </dependency>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -43,10 +43,6 @@
             <artifactId>kafka_2.13</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka-server-common</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
         </dependency>

--- a/junit5-extension/pom.xml
+++ b/junit5-extension/pom.xml
@@ -39,7 +39,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
-            <artifactId>kafka-clients</artifactId>
+            <artifactId>kafka_2.13</artifactId>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,8 @@
                 <!-- The user needs to provide this dependency only if they wish to use in-VM kafka with a Zookeeper
                      controller.  If they are using in-VM kafka in KRaft node, or container kafka with Zookeeper, it is not
                      required. -->
-                <optional>true</optional>
+                <scope>provided</scope>
+                <optional>true</optional> <!-- MNG-5227 -->
             </dependency>
             <dependency>
                 <groupId>org.awaitility</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -155,12 +155,6 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>org.apache.kafka</groupId>
-                <artifactId>kafka-server-common</artifactId>
-                <version>${kafka.version}</version>
-                <scope>provided</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>
                 <version>${zookeeper.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,10 @@
                         <artifactId>logback-classic</artifactId>
                     </exclusion>
                 </exclusions>
-                <scope>provided</scope>
+                <!-- The user needs to provide this dependency only if they wish to use in-VM kafka with a Zookeeper
+                     controller.  If they are using in-VM kafka in KRaft node, or container kafka with Zookeeper, it is not
+                     required. -->
+                <optional>true</optional>
             </dependency>
             <dependency>
                 <groupId>org.awaitility</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,7 @@
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-clients</artifactId>
                 <version>${kafka.version}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.kafka</groupId>
@@ -151,11 +152,13 @@
                         <artifactId>logback-classic</artifactId>
                     </exclusion>
                 </exclusions>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.kafka</groupId>
                 <artifactId>kafka-server-common</artifactId>
                 <version>${kafka.version}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.zookeeper</groupId>
@@ -175,6 +178,7 @@
                         <artifactId>logback-classic</artifactId>
                     </exclusion>
                 </exclusions>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.awaitility</groupId>


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

Change makes kafka and zookeeper a `provided` dependency.  This allows the user of the extension to choose 
which version of Kafka to use.  They is done by specifying kafka as a test dependency in their POM.

If the user wishes to use in-VM Kafka in Zookeeper mode, zookeeper needs to be added as test dependency too.

This branch shows the kind of changes that the user will be required to make:

https://github.com/kroxylicious/kroxylicious/compare/main...k-wall:kroxylicious:kafka-broker-explict-dependency


### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [x] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
