### PR TITLE
Bump zookeeper to 3.8.3 [CVE-2023-44981]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <lombok.version>1.18.30</lombok.version>
         <assertj-core.version>3.24.2</assertj-core.version>
         <findbugs.annotations.version>3.0.1u2</findbugs.annotations.version>
-        <zookeeper.version>3.8.2</zookeeper.version>
+        <zookeeper.version>3.8.3</zookeeper.version>
         <log4j.version>2.21.0</log4j.version>
         <awaitility.version>4.2.0</awaitility.version>
         <annotations.version>24.0.1</annotations.version>


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

Bump zookeeper (test dependency) to 3.8.3 to avoid CVE-2023-44981.

Not sure why Dependabot isn't processing this automatically.
https://github.com/kroxylicious/kroxylicious-junit5-extension/security/dependabot/1

For some reason it believes the version is ignored 
"Dependabot cannot update to the required version as all versions were ignored"



### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
