### PR TITLE
Fix #143: Default native kafka image tag from the version of Kafka on the classpath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,14 +13,14 @@ Please enumerate all user-facing changes using format `<githib issue/pr number>:
 
 ### Changes, deprecations and removals
 
-* It is now necessary to declare `org.apache.kafka:kafka_2.13` as a test dependency.  If you wish to use kafka in-vm with
-  zookeeper, org.apache.zookeeper:zookeeper must be declared as test dependency too.
+* It is now necessary to declare `org.apache.kafka:kafka_2.13` as a test dependency.
+* If you wish to use kafka in-vm with zookeeper, `org.apache.zookeeper:zookeeper` must be declared as test dependency too.
 * The way `TestcontainersKafkaCluster` determines the native image version tag to use for kafka and zookeeper is changed.
   Previously `TestcontainersKafkaCluster` always used the `latest-snapshot` version.  With this release, it will now default
   to use the version of the kafka native image that corresponds to the version of Kafka Broker found on the classpath.
-  This will give consumers of the test extension that have tests using TestcontainersKafkaCluster and InVMKafkaCluster
-  version consistency and test repeatability.  To get back the original behaviour, annotate the  `KafkaCluster` with
-  `@Version("latest-snapshot")`.
+  This will give consumers of the test extension that have tests using `TestcontainersKafkaCluster` test repeatability
+  and consumers who use both `InVMKafkaCluster` and `TestcontainersKafkaCluster` kafka broker version consistency.
+  To get back the original behaviour, annotate the  `KafkaCluster` with `@Version("latest-snapshot")`.
 
 ## 0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,20 @@ Please enumerate all user-facing changes using format `<githib issue/pr number>:
 
 ## 0.7.0
 
+* [#143](https://github.com/kroxylicious/kroxylicious-junit5-extension/issues/143): Default native kafka image tag from the version of Kafka on the classpath.
 * [#197](https://github.com/kroxylicious/kroxylicious-junit5-extension/issues/197): Consumer of the extension should be able to choose the version of the kafka dependency.
+
 
 ### Changes, deprecations and removals
 
-* It is now necessary to declare org.apache.kafka:kafka_2.13 as a test dependency.  If you wish to use kafka in-vm with zookeeper, org.apache.zookeeper:zookeeper
-  must be a test dependency too.
-
+* It is now necessary to declare `org.apache.kafka:kafka_2.13` as a test dependency.  If you wish to use kafka in-vm with
+  zookeeper, org.apache.zookeeper:zookeeper must be declared as test dependency too.
+* The way `TestcontainersKafkaCluster` determines the native image version tag to use for kafka and zookeeper is changed.
+  Previously `TestcontainersKafkaCluster` always used the `latest-snapshot` version.  With this release, it will now default
+  to use the version of the kafka native image that corresponds to the version of Kafka Broker found on the classpath.
+  This will give consumers of the test extension that have tests using TestcontainersKafkaCluster and InVMKafkaCluster
+  version consistency and test repeatability.  To get back the original behaviour, annotate the  `KafkaCluster` with
+  `@Version("latest-snapshot")`.
 
 ## 0.6.0
 

--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ Maven
     <dependency>
         <groupId>org.apache.kafka</groupId>
         <artifactId>kafka_2.13</artifactId>
-        <version>${kafka.version}</version> <!-- versions 3.3.0 or higher is known to work -->
+        <version>${kafka.version}</version> <!-- versions from 3.3.0 have been tested  -->
         <scope>test</scope>
     </dependency>
     <!-- Optional, required if you want to use in-VM kafka in Zookeeper mode. -->
     <dependency>
         <groupId>org.apache.zookeeper</groupId>
         <artifactId>zookeeper</artifactId>
-        <version>${zookeeper.version}</version> <!-- version 3.6.3 or higher is known to work -->
+        <version>${zookeeper.version}</version> <!-- versions from 3.6.3 have been tested -->
         <scope>test</scope>
     </dependency>
 </dependencies>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -41,6 +41,11 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka_2.13</artifactId>
         </dependency>
+        <!-- Dependency owing to use of org.apache.kafka.server.common.MetadataVersion.MINIMUM_BOOTSTRAP_VERSION -->
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-server-common</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
@@ -31,6 +31,7 @@ import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.common.utils.AppInfoParser;
 import org.junit.jupiter.api.TestInfo;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -76,9 +77,12 @@ public class KafkaClusterConfig {
 
     /**
      * Kafka version to be used for deploying kafka in container mode, e.g. "3.3.1".
+     * Defaults to the version available on the classpath.
+     * <br/>
+     * This value is ignored if execMode is not CONTAINER.
      */
     @Builder.Default
-    private String kafkaVersion = "latest";
+    private String kafkaVersion = AppInfoParser.getVersion();
 
     /**
      * name of SASL mechanism to be configured on kafka for the external listener, if null, anonymous communication

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
@@ -82,7 +82,8 @@ public class KafkaClusterConfig {
      * This value is ignored if execMode is not CONTAINER.
      */
     @Builder.Default
-    private String kafkaVersion = AppInfoParser.getVersion();
+    @lombok.NonNull
+    private String kafkaVersion = detectKafkaVersionFromClasspath();
 
     /**
      * name of SASL mechanism to be configured on kafka for the external listener, if null, anonymous communication
@@ -573,6 +574,11 @@ public class KafkaClusterConfig {
      */
     public String clusterId() {
         return isKraftMode() ? kafkaKraftClusterId : null;
+    }
+
+    private static String detectKafkaVersionFromClasspath() {
+        var version = AppInfoParser.getVersion();
+        return version == null || version.equals("unknown" /* AppInfoParser.DEFAULT_VALUE */) ? Version.LATEST : version;
     }
 
     /**

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
@@ -578,7 +578,8 @@ public class KafkaClusterConfig {
 
     private static String detectKafkaVersionFromClasspath() {
         var version = AppInfoParser.getVersion();
-        return version == null || version.equals("unknown" /* AppInfoParser.DEFAULT_VALUE */) ? Version.LATEST_RELEASE : version;
+        var appInfoParserUnknown = "unknown"; // Defined by AppInfoParser.DEFAULT_VALUE. Symbol is package-private.
+        return version == null || version.equals(appInfoParserUnknown) ? Version.LATEST_RELEASE : version;
     }
 
     /**

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
@@ -79,7 +79,7 @@ public class KafkaClusterConfig {
      * Kafka version to be used for deploying kafka in container mode, e.g. "3.3.1".
      * Defaults to the version available on the classpath.
      * <br/>
-     * This value is ignored if execMode is not CONTAINER.
+     * The value is only used when execMode is {@link KafkaClusterExecutionMode#CONTAINER}.
      */
     @Builder.Default
     @lombok.NonNull

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
@@ -578,7 +578,7 @@ public class KafkaClusterConfig {
 
     private static String detectKafkaVersionFromClasspath() {
         var version = AppInfoParser.getVersion();
-        return version == null || version.equals("unknown" /* AppInfoParser.DEFAULT_VALUE */) ? Version.LATEST : version;
+        return version == null || version.equals("unknown" /* AppInfoParser.DEFAULT_VALUE */) ? Version.LATEST_RELEASE : version;
     }
 
     /**

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterFactory.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterFactory.java
@@ -98,7 +98,7 @@ public class KafkaClusterFactory {
     }
 
     private static String getKafkaVersion(KafkaClusterConfig clusterConfig) {
-        return System.getenv().getOrDefault(KAFKA_VERSION, clusterConfig.getKafkaVersion() == null ? "latest" : clusterConfig.getKafkaVersion());
+        return System.getenv().getOrDefault(KAFKA_VERSION, clusterConfig.getKafkaVersion());
     }
 
     private static boolean convertClusterKraftMode(String mode, boolean defaultMode) {

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterFactory.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterFactory.java
@@ -62,6 +62,7 @@ public class KafkaClusterFactory {
         }
 
         var clusterMode = getExecutionMode(clusterConfig);
+        var kafkaVersion = getKafkaVersion(clusterConfig);
         var kraftMode = convertClusterKraftMode(System.getenv().get(TEST_CLUSTER_KRAFT_MODE), true);
         var builder = clusterConfig.toBuilder();
 
@@ -73,7 +74,6 @@ public class KafkaClusterFactory {
             builder.kraftMode(kraftMode);
         }
 
-        var kafkaVersion = System.getenv().getOrDefault(KAFKA_VERSION, "latest");
         builder.kafkaVersion(kafkaVersion);
 
         var actual = builder.build();
@@ -95,6 +95,10 @@ public class KafkaClusterFactory {
     private static KafkaClusterExecutionMode getExecutionMode(KafkaClusterConfig clusterConfig) {
         return KafkaClusterExecutionMode.convertClusterExecutionMode(System.getenv().get(TEST_CLUSTER_EXECUTION_MODE),
                 clusterConfig.getExecMode() == null ? KafkaClusterExecutionMode.IN_VM : clusterConfig.getExecMode());
+    }
+
+    private static String getKafkaVersion(KafkaClusterConfig clusterConfig) {
+        return System.getenv().getOrDefault(KAFKA_VERSION, clusterConfig.getKafkaVersion() == null ? "latest" : clusterConfig.getKafkaVersion());
     }
 
     private static boolean convertClusterKraftMode(String mode, boolean defaultMode) {

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/Version.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/Version.java
@@ -19,10 +19,13 @@ import io.kroxylicious.testing.kafka.api.KafkaClusterConstraint;
 @Target({ ElementType.FIELD, ElementType.PARAMETER })
 @KafkaClusterConstraint
 public @interface Version {
+    String LATEST = "latest";
+
     /**
-     * The value of the version.
+     * The value of the version, for instance, 3.6.0.  If value "latest" refers to the latest available kafka
+     * version.
      *
-     * @return the value
+     * @return the version
      */
     String value();
 }

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/Version.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/Version.java
@@ -19,11 +19,14 @@ import io.kroxylicious.testing.kafka.api.KafkaClusterConstraint;
 @Target({ ElementType.FIELD, ElementType.PARAMETER })
 @KafkaClusterConstraint
 public @interface Version {
-    String LATEST = "latest";
+    /** The latest release made by the kafka-native project. */
+    String LATEST_RELEASE = "latest";
+    /** The latest development snapshot created by kafka-native project's main build. */
+    String LATEST_SNAPSHOT = "latest-snapshot";
 
     /**
-     * The value of the version, for instance, 3.6.0.  If value "latest" refers to the latest available kafka
-     * version.
+     * The value of the version, for instance, 3.6.0. The value {@code LATEST_RELEASE} or {@code LATEST_SNAPSHOT}
+     * may also be used.
      *
      * @return the version
      */

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfigTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfigTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.TestInfo;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class KafkaClusterConfigTest {
 
@@ -117,6 +118,11 @@ class KafkaClusterConfigTest {
 
         // Then
         assertThat(brokerConfigs).hasSize(3);
+    }
+
+    @Test
+    void kafkaVersionDisallowsNulls() {
+        assertThatThrownBy(() -> kafkaClusterConfigBuilder.kafkaVersion(null)).isInstanceOf(NullPointerException.class);
     }
 
     private void assertNodeIdHasRole(KafkaClusterConfig kafkaClusterConfig, int nodeId, String expectedRole) {

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/TemplateTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/TemplateTest.java
@@ -157,7 +157,7 @@ public class TemplateTest {
 
     private static Stream<Version> versions() {
         return Stream.of(
-                version("latest"),
+                version(Version.LATEST),
                 version("3.6.0"),
                 version("3.5.1"),
                 version("3.4.0"),

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/TemplateTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/TemplateTest.java
@@ -39,7 +39,6 @@ import static io.kroxylicious.testing.kafka.common.ConstraintUtils.version;
 import static io.kroxylicious.testing.kafka.common.ConstraintUtils.zooKeeperCluster;
 import static io.kroxylicious.testing.kafka.junit5ext.AbstractExtensionTest.assertSameCluster;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(KafkaClusterExtension.class)
 public class TemplateTest {
@@ -55,7 +54,7 @@ public class TemplateTest {
                                          @DimensionMethodSource(value = "clusterSizes", clazz = TemplateTest.class) KafkaCluster cluster)
             throws ExecutionException, InterruptedException {
         try (var admin = Admin.create(cluster.getKafkaClientConfiguration())) {
-            assertEquals(admin.describeCluster().nodes().get().size(), cluster.getNumOfBrokers());
+            assertThat(admin.describeCluster().nodes().get()).hasSize(cluster.getNumOfBrokers());
         }
     }
 
@@ -63,7 +62,7 @@ public class TemplateTest {
     public void testMultipleClusterSizesWithAdminParameters(@DimensionMethodSource(value = "clusterSizes", clazz = TemplateTest.class) KafkaCluster cluster,
                                                             Admin admin)
             throws ExecutionException, InterruptedException {
-        assertEquals(admin.describeCluster().nodes().get().size(), cluster.getNumOfBrokers());
+        assertThat(admin.describeCluster().nodes().get()).hasSize(cluster.getNumOfBrokers());
     }
 
     static Set<List<Object>> observedCartesianProduct = new HashSet<>();
@@ -149,16 +148,16 @@ public class TemplateTest {
 
         @AfterAll
         public void afterAll() {
-            assertEquals(Set.of(
+            assertThat(observedTuples).isEqualTo(Set.of(
                     List.of(1, 1),
                     List.of(3, 1),
-                    List.of(3, -1)),
-                    observedTuples);
+                    List.of(3, -1)));
         }
     }
 
     private static Stream<Version> versions() {
         return Stream.of(
+                version("latest"),
                 version("3.6.0"),
                 version("3.5.1"),
                 version("3.4.0"),
@@ -179,7 +178,7 @@ public class TemplateTest {
 
         @AfterAll
         public void afterAll() {
-            assertEquals(versions().map(Version::value).map("latest-kafka-%s"::formatted).collect(Collectors.toSet()), observedVersions);
+            assertThat(observedVersions).isEqualTo(versions().map(Version::value).collect(Collectors.toSet()));
         }
     }
 }

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/TemplateTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/TemplateTest.java
@@ -157,7 +157,8 @@ public class TemplateTest {
 
     private static Stream<Version> versions() {
         return Stream.of(
-                version(Version.LATEST),
+                version(Version.LATEST_RELEASE),
+                version(Version.LATEST_SNAPSHOT),
                 version("3.6.0"),
                 version("3.5.1"),
                 version("3.4.0"),

--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,16 @@
                 </exclusions>
                 <scope>provided</scope>
             </dependency>
+            <!-- org.apache.kafka.server.common.MetadataVersion.MINIMUM_BOOTSTRAP_VERSION -->
+            <dependency>
+                <groupId>org.apache.kafka</groupId>
+                <artifactId>kafka-server-common</artifactId>
+                <version>${kafka.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+
+
             <dependency>
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

Default native kafka image tag from the version of Kafka on the classpath.

Previously TestcontainerKaftaCluster used image tag `latest-snapshot` which meant tests we using the last image build from kafka-natives CI - not at all stable. 


why:
This change, coupled with #197. allows the user of the junit extension a
single way to control the version of the broker used by extension, regardless
of whether they use in-vm, container or both.

_Please describe your pull request_

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
