### PR TITLE
Fix #211: Use spotbugs annotations for nullability annotations

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -109,8 +109,8 @@
             <artifactId>awaitility</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>annotations</artifactId>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
@@ -31,9 +31,9 @@ import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.config.SslConfigs;
 import org.apache.kafka.common.config.internals.BrokerSecurityConfigs;
 import org.apache.kafka.common.security.auth.SecurityProtocol;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.TestInfo;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import kafka.server.KafkaConfig;
 import lombok.Builder;
 import lombok.Getter;
@@ -216,7 +216,7 @@ public class KafkaClusterConfig {
      * @param nodeId kafka <code>node.id</code>
      * @return broker configuration.
      */
-    @NotNull
+    @NonNull
     public ConfigHolder generateConfigForSpecificNode(KafkaEndpoints kafkaEndpoints, int nodeId) {
         final var role = determineRole(nodeId);
         Properties nodeConfiguration = new Properties();
@@ -267,13 +267,13 @@ public class KafkaClusterConfig {
         return configHolder;
     }
 
-    @NotNull
+    @NonNull
     private ConfigHolder configureController(KafkaEndpoints kafkaEndpoints, int nodeId, Properties nodeConfiguration) {
         return new ConfigHolder(nodeConfiguration, null, null, null,
                 nodeId, kafkaKraftClusterId);
     }
 
-    @NotNull
+    @NonNull
     private ConfigHolder configureBroker(KafkaEndpoints kafkaEndpoints, int nodeId, TreeMap<String, String> protocolMap, TreeMap<String, String> listeners,
                                          TreeMap<String, String> advertisedListeners, TreeSet<String> earlyStart, Properties nodeConfiguration) {
         final ConfigHolder configHolder;
@@ -298,7 +298,7 @@ public class KafkaClusterConfig {
         return configHolder;
     }
 
-    @NotNull
+    @NonNull
     private String determineRole(int nodeId) {
         var roles = new ArrayList<String>();
 

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
@@ -35,8 +35,8 @@ import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Time;
 import org.apache.zookeeper.server.ServerCnxnFactory;
 import org.apache.zookeeper.server.ZooKeeperServer;
-import org.jetbrains.annotations.NotNull;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import kafka.server.KafkaConfig;
 import kafka.server.KafkaRaftServer;
 import kafka.server.KafkaServer;
@@ -101,7 +101,7 @@ public class InVMKafkaCluster implements KafkaCluster, KafkaClusterConfig.KafkaE
                 statusCode, message, illegalStateException);
     }
 
-    @NotNull
+    @NonNull
     private Server buildKafkaServer(KafkaClusterConfig.ConfigHolder c) {
         KafkaConfig config = buildBrokerConfig(c);
         Option<String> threadNamePrefix = Option.apply(null);
@@ -126,7 +126,7 @@ public class InVMKafkaCluster implements KafkaCluster, KafkaClusterConfig.KafkaE
      * older than 3.5.0. This is to enable users to downgrade the broker used for embedded testing rather
      * than forcing them to increase their kafka-clients version to 3.5.0 (broker 3.5.0 requires kafka-clients 3.5.0)
      */
-    @NotNull
+    @NonNull
     private Server instantiateKraftServer(KafkaConfig config, Option<String> threadNamePrefix) {
         Object kraftServer = construct(KafkaRaftServer.class, config, Time.SYSTEM)
                 .orElseGet(() -> construct(KafkaRaftServer.class, config, Time.SYSTEM, threadNamePrefix).orElseThrow());
@@ -157,7 +157,7 @@ public class InVMKafkaCluster implements KafkaCluster, KafkaClusterConfig.KafkaE
                 });
     }
 
-    @NotNull
+    @NonNull
     private KafkaConfig buildBrokerConfig(KafkaClusterConfig.ConfigHolder c) {
         Properties properties = new Properties();
         properties.putAll(c.getProperties());
@@ -167,7 +167,7 @@ public class InVMKafkaCluster implements KafkaCluster, KafkaClusterConfig.KafkaE
         return new KafkaConfig(properties);
     }
 
-    @NotNull
+    @NonNull
     private Path getBrokerLogDir(int brokerNum) {
         return this.tempDirectory.resolve(String.format("broker-%d", brokerNum));
     }

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
@@ -41,7 +41,6 @@ import java.util.stream.Stream;
 
 import org.apache.kafka.common.config.SslConfigs;
 import org.awaitility.Awaitility;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.TestInfo;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
@@ -61,6 +60,7 @@ import com.github.dockerjava.api.model.Bind;
 import com.github.dockerjava.api.model.VersionComponent;
 import com.github.dockerjava.api.model.Volume;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import kafka.server.KafkaConfig;
 import lombok.SneakyThrows;
 
@@ -191,7 +191,7 @@ public class TestcontainersKafkaCluster implements Startable, KafkaCluster, Kafk
         clusterConfig.getBrokerConfigs(() -> this).forEach(holder -> nodes.put(holder.getBrokerNum(), buildKafkaContainer(holder)));
     }
 
-    @NotNull
+    @NonNull
     private KafkaContainer buildKafkaContainer(KafkaClusterConfig.ConfigHolder holder) {
         String netAlias = "broker-" + holder.getBrokerNum();
         Properties properties = new Properties();
@@ -227,7 +227,7 @@ public class TestcontainersKafkaCluster implements Startable, KafkaCluster, Kafk
         return kafkaContainer;
     }
 
-    @NotNull
+    @NonNull
     private String getBrokerLogDirectory(int brokerNum) {
         return KAFKA_CONTAINER_MOUNT_POINT + "/broker-" + brokerNum;
     }

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfigTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfigTest.java
@@ -7,10 +7,11 @@ package io.kroxylicious.testing.kafka.common;
 
 import java.util.stream.Stream;
 
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -126,7 +127,7 @@ class KafkaClusterConfigTest {
 
     static class EndpointConfig implements KafkaClusterConfig.KafkaEndpoints {
 
-        @NotNull
+        @NonNull
         private static EndpointPair generateEndpoint(int nodeId, int basePort) {
             final int port = basePort + nodeId;
             return new EndpointPair(new Endpoint("0.0.0.0", port), new Endpoint("localhost", port));

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/common/KeytoolCertificateGeneratorTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/common/KeytoolCertificateGeneratorTest.java
@@ -12,8 +12,9 @@ import java.security.KeyStoreException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -64,7 +65,7 @@ class KeytoolCertificateGeneratorTest {
         assertThat(ts.getType()).isEqualTo(generator.getTrustStoreType());
     }
 
-    @NotNull
+    @NonNull
     private List<String> aliasList(KeyStore ks) throws KeyStoreException {
         List<String> aliases = new ArrayList<>();
         ks.aliases().asIterator().forEachRemaining(alias -> aliases.add(alias));

--- a/junit5-extension/pom.xml
+++ b/junit5-extension/pom.xml
@@ -72,6 +72,10 @@
             <artifactId>log4j-slf4j-impl</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/junit5-extension/src/main/java/io/kroxylicious/testing/kafka/junit5ext/KafkaClusterExtension.java
+++ b/junit5-extension/src/main/java/io/kroxylicious/testing/kafka/junit5ext/KafkaClusterExtension.java
@@ -58,8 +58,6 @@ import org.apache.kafka.common.serialization.UUIDSerializer;
 import org.apache.kafka.common.serialization.VoidDeserializer;
 import org.apache.kafka.common.serialization.VoidSerializer;
 import org.apache.kafka.common.utils.Bytes;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
@@ -75,6 +73,9 @@ import org.junit.platform.commons.support.AnnotationSupport;
 import org.junit.platform.commons.support.HierarchyTraversalMode;
 import org.junit.platform.commons.util.ExceptionUtils;
 import org.junit.platform.commons.util.ReflectionUtils;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.api.KafkaClusterConstraint;
@@ -240,7 +241,7 @@ public class KafkaClusterExtension implements
                 });
     }
 
-    @NotNull
+    @NonNull
     private static List<? extends List<Annotation>> invokeConstraintsMethodSource(ExtensionContext context,
                                                                                   ConstraintsMethodSource methodSource) {
         Method testTemplateMethod = context.getRequiredTestMethod();
@@ -305,7 +306,7 @@ public class KafkaClusterExtension implements
                 .toList();
     }
 
-    @NotNull
+    @NonNull
     private static List<Annotation> invokeDimensionMethodSource(ExtensionContext context,
                                                                 DimensionMethodSource methodSource) {
         Method testTemplateMethod = context.getRequiredTestMethod();
@@ -367,14 +368,14 @@ public class KafkaClusterExtension implements
                 testTemplateMethod, requiredTestClass, source), KafkaClusterConstraint.class);
     }
 
-    @NotNull
+    @NonNull
     private static Method getTargetMethod(Class<?> clazz, Class<?> methodClazz, String methodName) throws NoSuchMethodException {
         Class<?> target = methodClazz == null || methodClazz == Void.class ? clazz : methodClazz;
         return ReflectionUtils.makeAccessible(target.getDeclaredMethod(methodName));
     }
 
     @SuppressWarnings("unchecked")
-    @NotNull
+    @NonNull
     private static <T> List<T> coerceToList(String methodName,
                                             Class<? extends Annotation> annotationType,
                                             Method testTemplateMethod, Class<?> requiredTestClass, Object source) {
@@ -397,7 +398,7 @@ public class KafkaClusterExtension implements
         return list;
     }
 
-    @NotNull
+    @NonNull
     private static ParameterResolutionException returnTypeError(Method testTemplateMethod,
                                                                 String methodName,
                                                                 Class<? extends Annotation> annotationType,
@@ -1007,7 +1008,7 @@ public class KafkaClusterExtension implements
         return new Closeable<>(sourceElement, clusterName, c);
     }
 
-    @NotNull
+    @NonNull
     private static KroxyliciousTestInfo generateTestInfo(ExtensionContext extensionContext) {
         return new KroxyliciousTestInfo(extensionContext.getDisplayName(), extensionContext.getTestClass(), extensionContext.getTestMethod(), extensionContext.getTags());
     }
@@ -1018,7 +1019,7 @@ public class KafkaClusterExtension implements
      * @return A mutable list of annotations from the source element that are meta-annotated with
      * the given {@code metaAnnotationType}.
      */
-    @NotNull
+    @NonNull
     private static ArrayList<Annotation> getConstraintAnnotations(AnnotatedElement sourceElement, Class<? extends Annotation> metaAnnotationType) {
         ArrayList<Annotation> constraints;
         if (AnnotationSupport.isAnnotated(sourceElement, metaAnnotationType)) {
@@ -1031,19 +1032,19 @@ public class KafkaClusterExtension implements
         return constraints;
     }
 
-    @NotNull
+    @NonNull
     private static ArrayList<Annotation> filterAnnotations(List<Annotation> annotations,
                                                            Class<? extends Annotation> metaAnnotationType) {
         return filterAnnotations(annotations.stream(), metaAnnotationType);
     }
 
-    @NotNull
+    @NonNull
     private static ArrayList<Annotation> filterAnnotations(Annotation[] annotations,
                                                            Class<? extends Annotation> metaAnnotationType) {
         return filterAnnotations(Arrays.stream(annotations), metaAnnotationType);
     }
 
-    @NotNull
+    @NonNull
     private static ArrayList<Annotation> filterAnnotations(Stream<Annotation> annotations,
                                                            Class<? extends Annotation> metaAnnotationType) {
         ArrayList<Annotation> constraints = annotations
@@ -1094,7 +1095,7 @@ public class KafkaClusterExtension implements
                 });
     }
 
-    @NotNull
+    @NonNull
     private static List<String> classNames(Collection<? extends Class<?>> constraints) {
         return constraints.stream().map(Class::getName).sorted().toList();
     }

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/AbstractExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/AbstractExtensionTest.java
@@ -13,7 +13,8 @@ import org.apache.kafka.clients.admin.DescribeClusterResult;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.jetbrains.annotations.NotNull;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 
@@ -26,7 +27,7 @@ public abstract class AbstractExtensionTest {
         }
     }
 
-    @NotNull
+    @NonNull
     protected static DescribeClusterResult describeCluster(Admin admin) throws InterruptedException, ExecutionException {
         DescribeClusterResult describeClusterResult = admin.describeCluster();
         describeClusterResult.controller().get();

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <testcontainers.version>1.19.1</testcontainers.version>
         <lombok.version>1.18.30</lombok.version>
         <assertj-core.version>3.24.2</assertj-core.version>
-        <findbugs.annotations.version>3.0.1u2</findbugs.annotations.version>
+        <spotbugs-annotations.version>4.8.0</spotbugs-annotations.version>
         <zookeeper.version>3.8.3</zookeeper.version>
         <log4j.version>2.21.0</log4j.version>
         <awaitility.version>4.2.0</awaitility.version>
@@ -205,9 +205,9 @@
                 <version>${duct-tape.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.google.code.findbugs</groupId>
-                <artifactId>annotations</artifactId>
-                <version>${findbugs.annotations.version}</version>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-annotations</artifactId>
+                <version>${spotbugs-annotations.version}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring

### Description

Use spotbugs annotations for nullability annotations rather than jetbrains annotations.
We already adopted the convention on the main kroxylicious project, we should do that here too.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
