### PR TITLE
Remove the jetbrains annotation dependency

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -84,10 +84,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jetbrains</groupId>
-            <artifactId>annotations</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.rnorth.duct-tape</groupId>
             <artifactId>duct-tape</artifactId>
         </dependency>

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -89,10 +89,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jetbrains</groupId>
-            <artifactId>annotations</artifactId>
-        </dependency>
-        <dependency>
             <!-- Note we use System.Logger facade in src/main/java. log4j2 only for the tests -->
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>

--- a/junit5-extension/pom.xml
+++ b/junit5-extension/pom.xml
@@ -46,10 +46,6 @@
             <artifactId>junit-jupiter-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jetbrains</groupId>
-            <artifactId>annotations</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/ParameterExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/ParameterExtensionTest.java
@@ -22,11 +22,11 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.SaslAuthenticationException;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.testcontainers.shaded.org.awaitility.Awaitility;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import kafka.server.KafkaConfig;
 
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
@@ -276,7 +276,7 @@ public class ParameterExtensionTest extends AbstractExtensionTest {
 
     }
 
-    @NotNull
+    @NonNull
     private String createTopic(Admin admin) throws Exception {
         var topic = UUID.randomUUID().toString();
         admin.createTopics(List.of(new NewTopic(topic, 1, (short) 1))).all().get(5, TimeUnit.SECONDS);

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,6 @@
         <zookeeper.version>3.8.3</zookeeper.version>
         <log4j.version>2.21.1</log4j.version>
         <awaitility.version>4.2.0</awaitility.version>
-        <annotations.version>24.0.1</annotations.version>
         <duct-tape.version>1.0.8</duct-tape.version>
         <mockito.version>5.7.0</mockito.version>
 
@@ -203,11 +202,6 @@
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
                 <version>${lombok.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jetbrains</groupId>
-                <artifactId>annotations</artifactId>
-                <version>${annotations.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.rnorth.duct-tape</groupId>


### PR DESCRIPTION

### Type of change


- Refactoring

### Description

Why: we'd agreed to use `edu.umd.cs.findbugs.annotations` already.  We'd mostly switched too, but this remanent was left behind.

This is a compile time tool, so there's no user facing change.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
