### PR TITLE
[release] workaround for OSSRH-66257 - java.util.AbstractList.modCount accessible: module java.base does not "opens java.util"

### DIFF
--- a/scripts/transition-staging-repository-state.sh
+++ b/scripts/transition-staging-repository-state.sh
@@ -63,7 +63,9 @@ elif [[ ${STATE} ]]; then
 
   case ${STATE} in
     close|drop|release)
-      mvn ${PLUGIN}:${STATE} "${MVN_ARGS[@]}" -DstagingRepositoryId=${STAGING_REPO_IDS}
+      # Workaround for https://issues.sonatype.org/browse/OSSRH-66257
+      MAVEN_OPTS="--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.desktop/java.awt.font=ALL-UNNAMED" \
+        mvn ${PLUGIN}:${STATE} "${MVN_ARGS[@]}" -DstagingRepositoryId=${STAGING_REPO_IDS}
       ;;
     *)
       usage


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description

Apply workaround for avoid an exception during release deploy. 
See: https://issues.sonatype.org/browse/OSSRH-66257.
See #238 

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
