### PR TITLE
Release instruction should use rebase/merge strategy.

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -7,7 +7,7 @@ The component is released using GitHub automation.
 At a high level, the process is as follows:
 
 1. The developer adds their private key/passphrase as repository secrets
-1. The workflow `stage_release` tags, builds/signs the release, and stages the release on a Nexus staging repository.
+1. The workflow `stage_release` tags, builds/signs the release, and stages the release on a Nexus staging repository. This process uses the GitHub machine account [kroxylicious-robot](https://github.com/kroxylicious-robot) and a user token owned by Sonatype account `kroxylicious` account.
 1. The stage release is verified using manual verification steps.
 1. The workflow `deploy_release` releases from the staged repository to Maven Central.
 1. The developer removes their private key/passphrase as repository secrets.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -62,7 +62,7 @@ The local changes made to `T`'s POM can be reverted.
 
 1. Run [deploy_workflow](https://github.com/kroxylicious/kroxylicious-junit5-extension/actions/workflows/deploy_release.yml)
    setting the `next-state` to `release` to publish the artefact.
-2. Merge release PR.
+2. Merge release PR (use Rebase and Merge strategy).
 3. Manually create the release notes for release by following the
    [Draft a new release](https://github.com/kroxylicious/kroxylicious-junit5-extension/releases) workflow.  Copy
    the release note content from the [CHANGELOG.md](./CHANGELOG.md).


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Documentation

### Description

When merging the release PR, it is important to use the *rebase/merge* strategy.

If this is not done, the SHA of the release tag won't align with the SHA of the commit history of main.  (For squash - the commit for the tag will be missing from main. For merge commit, the commit representing the merge will cause the divergence).  You'll see a message like this in the Git Hub UI when viewing the the release tag.   (v0.7.0 suffered from this https://github.com/kroxylicious/kroxylicious-junit5-extension/tree/v0.7.0)

> This commit does not belong to any branch on this repository, and may belong to a fork outside of the repository.


### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
