### PR TITLE
Allow test Kafka Clusters to use SASL SCRAM-SHA and OAUTH bearer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,11 @@ Please enumerate all user-facing changes using format `<githib issue/pr number>:
 
 * For SCRAM support in KRaft mode,  the Kafka Broker must be 3.5 or above and it must use storage format IBP_3_5_IV2
   or higher.  If using CONTAINER mode, be aware that support for this combination was introduced in
-  [kafka-native 0.9.0](https://github.com/ozangunalp/kafka-native/releases/tag/v0.9.0)
+  [kafka-native 0.9.0](https://github.com/ozangunalp/kafka-native/releases/tag/v0.9.0).
+* In KRaft mode, the metadata storage format used by the test clusters defaults to `MetadataVersion.LATEST_PRODUCTION`
+  rather than `MINIMUM_BOOTSTRAP_VERSION` as was the case in previous releases.  To get back the old behaviour, override
+  the `inter.broker.protocol.version` broker configuration option and set the desired version. This config option
+  also controls the metadata storage format when the storage is formatted for the first time.
 
 ## 0.8.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ Please enumerate all user-facing changes using format `<githib issue/pr number>:
 ## 0.9.0
 
 
-
+* [#322](https://github.com/kroxylicious/kroxylicious-junit5-extension/pull/322): Allow test Kafka Clusters to use SASL SCRAM-SHA and OAUTH bearer
 * [#289](https://github.com/kroxylicious/kroxylicious-junit5-extension/pull/289): Bump org.testcontainers:testcontainers-bom from 1.19.6 to 1.19.7
 * [#283](https://github.com/kroxylicious/kroxylicious-junit5-extension/pull/283): Bump kafka.version from 3.6.1 to 3.7.0.
+
+### Changes, deprecations and removals
+
+* For SCRAM support in KRaft mode,  the Kafka Broker must be 3.5 or above and it must use storage format IBP_3_5_IV2
+  or higher.  If using CONTAINER mode, be aware that support for this combination was introduced in
+  [kafka-native 0.9.0](https://github.com/ozangunalp/kafka-native/releases/tag/v0.9.0)
 
 ## 0.8.1
 

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/Utils.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/Utils.java
@@ -24,7 +24,11 @@ import java.util.stream.Collectors;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.NewPartitionReassignment;
 import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.admin.ScramCredentialInfo;
+import org.apache.kafka.clients.admin.ScramMechanism;
 import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.clients.admin.UserScramCredentialAlteration;
+import org.apache.kafka.clients.admin.UserScramCredentialUpsertion;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.TopicPartitionInfo;
 import org.apache.kafka.common.errors.InvalidReplicationFactorException;
@@ -46,6 +50,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 public class Utils {
     private static final Logger log = getLogger(Utils.class);
     private static final String CONSISTENCY_TEST = "__org_kroxylicious_testing_consistencyTest";
+    private static final int SCRAM_ITERATIONS = 4096;
 
     private Utils() {
     }
@@ -55,10 +60,10 @@ public class Utils {
      * have at least one replica elsewhere in the cluster.
      *
      * @param connectionConfig the connection config
-     * @param fromNodeId nodeId being evacuated
-     * @param toNodeId replacement nodeId
-     * @param timeout the timeout
-     * @param timeUnit the time unit
+     * @param fromNodeId       nodeId being evacuated
+     * @param toNodeId         replacement nodeId
+     * @param timeout          the timeout
+     * @param timeUnit         the time unit
      */
     public static void awaitReassignmentOfKafkaInternalTopicsIfNecessary(Map<String, Object> connectionConfig, int fromNodeId, int toNodeId, int timeout,
                                                                          TimeUnit timeUnit) {
@@ -113,9 +118,9 @@ public class Utils {
      * To Verify that all the expected brokers are in the cluster we create a topic with a replication factor = to the expected number of brokers.
      * We then poll describeTopics until
      *
-     * @param connectionConfig the connection config
-     * @param timeout the timeout
-     * @param timeUnit the time unit
+     * @param connectionConfig    the connection config
+     * @param timeout             the timeout
+     * @param timeUnit            the time unit
      * @param expectedBrokerCount the expected broker count
      */
     public static void awaitExpectedBrokerCountInClusterViaTopic(Map<String, Object> connectionConfig, int timeout, TimeUnit timeUnit, Integer expectedBrokerCount) {
@@ -160,6 +165,22 @@ public class Utils {
                         }
                         return isQuorate;
                     });
+        }
+    }
+
+    public static void createUsersOnClusterIfNecessary(Map<String, Object> connectionConfig, KafkaClusterConfig clusterConfig) {
+        var users = clusterConfig.getUsers();
+        var saslMechanism = clusterConfig.getSaslMechanism();
+        if (users.isEmpty() || !clusterConfig.isSaslScram()) {
+            return;
+        }
+        var sci = new ScramCredentialInfo(ScramMechanism.fromMechanismName(saslMechanism), SCRAM_ITERATIONS);
+        try (var admin = Admin.create(connectionConfig)) {
+            // TODO fail gracefully if KRaft and Metaddata version does not yet support SCRAM
+            admin.alterUserScramCredentials(users.entrySet().stream()
+                    .map(e -> new UserScramCredentialUpsertion(e.getKey(), sci, e.getValue()))
+                    .map(UserScramCredentialAlteration.class::cast)
+                    .toList()).all().toCompletionStage().toCompletableFuture().join();
         }
     }
 
@@ -229,14 +250,15 @@ public class Utils {
         var throwable = potentiallyWrapped instanceof CompletionException && potentiallyWrapped.getCause() != null ? potentiallyWrapped.getCause() : potentiallyWrapped;
         boolean retriable = throwable instanceof RetriableException
                 && (throwable.getMessage() == null
-                        || !throwable.getMessage().contains("The AdminClient is not accepting new calls") /* workaround for KAFKA-15507 */ );
+                        || !throwable.getMessage().contains("The AdminClient is not accepting new calls") /* workaround for KAFKA-15507 */);
         return retriable || throwable instanceof InvalidReplicationFactorException
                 || (throwable instanceof TopicExistsException && throwable.getMessage().contains("is marked for deletion"));
     }
 
     /**
      * Factory for {@link Awaitility#await()} preconfigured with defaults.
-     * @param timeout at most timeout
+     *
+     * @param timeout  at most timeout
      * @param timeUnit at most {@link TimeUnit}
      * @return preconfigured factory
      */

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/Utils.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/Utils.java
@@ -176,7 +176,10 @@ public class Utils {
         }
         var sci = new ScramCredentialInfo(ScramMechanism.fromMechanismName(saslMechanism), SCRAM_ITERATIONS);
         try (var admin = Admin.create(connectionConfig)) {
-            // TODO fail gracefully if KRaft and Metaddata version does not yet support SCRAM
+            // We have no reliable to tell if the cluster actually supports Scram. In the KRaft case, the Kafka Broker
+            // needs to be running at least version 3.5 and using the metadata format IBP_3_5_IV2.
+            // As a client, we have no way to observe the metadata format version in use by the Broker.
+            // The error message from alterUserScramCredentials is sufficiently clear if support is not present.
             admin.alterUserScramCredentials(users.entrySet().stream()
                     .map(e -> new UserScramCredentialUpsertion(e.getKey(), sci, e.getValue()))
                     .map(UserScramCredentialAlteration.class::cast)

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
@@ -33,6 +33,10 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.ScramCredentialInfo;
+import org.apache.kafka.clients.admin.ScramMechanism;
+import org.apache.kafka.clients.admin.UserScramCredentialAlteration;
+import org.apache.kafka.clients.admin.UserScramCredentialUpsertion;
 import org.apache.kafka.common.utils.Exit;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.server.common.MetadataVersion;
@@ -63,6 +67,7 @@ public class InVMKafkaCluster implements KafkaCluster, KafkaClusterConfig.KafkaE
     private static final System.Logger LOGGER = System.getLogger(InVMKafkaCluster.class.getName());
     private static final PrintStream LOGGING_PRINT_STREAM = LoggingPrintStream.loggingPrintStream(LOGGER, System.Logger.Level.DEBUG);
     private static final int STARTUP_TIMEOUT = 30;
+    private static final int SCRAM_ITERATIONS = 4096;
 
     private final KafkaClusterConfig clusterConfig;
     private final Path tempDirectory;
@@ -124,6 +129,9 @@ public class InVMKafkaCluster implements KafkaCluster, KafkaClusterConfig.KafkaE
 
     private static void prepareLogDirsForKraft(String clusterId, KafkaConfig config, Seq<String> directories) {
         try {
+            // Default the metadata version from the IBP version specified in config in the same way as kafka.tools.StorageTool.
+            var metadataVersion = MetadataVersion.fromVersionString(
+                    config.interBrokerProtocolVersionString() == null ? MetadataVersion.LATEST_PRODUCTION.version() : config.interBrokerProtocolVersionString());
             // in kafka 3.7.0 the MetadataProperties class moved package, we use reflection to enable the extension to work with
             // the old and new class.
             Method buildMetadataProperties = StorageTool.class.getDeclaredMethod("buildMetadataProperties", String.class, KafkaConfig.class);
@@ -132,7 +140,7 @@ public class InVMKafkaCluster implements KafkaCluster, KafkaClusterConfig.KafkaE
                     boolean.class);
             // note ignoreFormatter=true so tolerate a log directory which is already formatted. this is
             // required to support start/stop.
-            formatCommand.invoke(null, LOGGING_PRINT_STREAM, directories, metaProperties, MetadataVersion.latestProduction(), true);
+            formatCommand.invoke(null, LOGGING_PRINT_STREAM, directories, metaProperties, metadataVersion, true);
         }
         catch (Exception e) {
             throw new RuntimeException("failed to prepare log dirs for KRaft", e);
@@ -211,7 +219,7 @@ public class InVMKafkaCluster implements KafkaCluster, KafkaClusterConfig.KafkaE
                 TimeUnit.SECONDS,
                 clusterConfig.getBrokersNum());
 
-        Utils.createUsersOnClusterIfNecessary(anonConnectConfigForCluster, clusterConfig);
+        createUsersOnClusterIfNecessary(anonConnectConfigForCluster, clusterConfig);
 
     }
 
@@ -478,5 +486,22 @@ public class InVMKafkaCluster implements KafkaCluster, KafkaClusterConfig.KafkaE
     @Override
     public @NonNull Admin createAdmin() {
         return CloseableAdmin.create(clusterConfig.getAnonConnectConfigForCluster(buildBrokerList(nodeId -> getEndpointPair(Listener.ANON, nodeId))));
+    }
+
+    private static void createUsersOnClusterIfNecessary(Map<String, Object> connectionConfig, KafkaClusterConfig clusterConfig) {
+        var users = clusterConfig.getUsers();
+        var saslMechanism = clusterConfig.getSaslMechanism();
+        if (users.isEmpty() || !clusterConfig.isSaslScram()) {
+            return;
+        }
+        var sci = new ScramCredentialInfo(ScramMechanism.fromMechanismName(saslMechanism), SCRAM_ITERATIONS);
+        try (var admin = Admin.create(connectionConfig)) {
+            // In the KRaft case, the broker needs to be using the metadata format IBP_3_5_IV2. If this is not
+            // the case, alterUserScramCredentials will fail. The error message from Kafka is obvious.
+            admin.alterUserScramCredentials(users.entrySet().stream()
+                    .map(e -> new UserScramCredentialUpsertion(e.getKey(), sci, e.getValue()))
+                    .map(UserScramCredentialAlteration.class::cast)
+                    .toList()).all().toCompletionStage().toCompletableFuture().join();
+        }
     }
 }

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
@@ -43,7 +43,6 @@ import java.util.stream.Stream;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.common.config.SslConfigs;
 import org.awaitility.Awaitility;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.TestInfo;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
@@ -832,7 +831,7 @@ public class TestcontainersKafkaCluster implements Startable, KafkaCluster, Kafk
         return CloseableAdmin.create(clusterConfig.getAnonConnectConfigForCluster(buildBrokerList(nodeId -> getEndpointPair(Listener.ANON, nodeId))));
     }
 
-    @NotNull
+    @NonNull
     private String buildScramUsersEnvVar() {
         return this.clusterConfig.getUsers().entrySet().stream()
                 .map(e -> "%s=[name=%s,password=%s]".formatted(this.clusterConfig.getSaslMechanism(), e.getKey(), e.getValue()))

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
@@ -334,10 +334,14 @@ public class TestcontainersKafkaCluster implements Startable, KafkaCluster, Kafk
                 zookeeper.start();
             }
             Startables.deepStart(nodes.values().stream()).get(READY_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+
+            var anonConnectConfigForCluster = clusterConfig.getAnonConnectConfigForCluster(buildBrokerList(nodeId -> getEndpointPair(Listener.ANON, nodeId)));
             awaitExpectedBrokerCountInClusterViaTopic(
-                    clusterConfig.getAnonConnectConfigForCluster(buildBrokerList(nodeId -> getEndpointPair(Listener.ANON, nodeId))),
+                    anonConnectConfigForCluster,
                     READY_TIMEOUT_SECONDS, TimeUnit.SECONDS,
                     clusterConfig.getBrokersNum());
+
+            Utils.createUsersOnClusterIfNecessary(anonConnectConfigForCluster, clusterConfig);
         }
         catch (InterruptedException | ExecutionException | TimeoutException e) {
             if (e instanceof InterruptedException) {

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/KafkaClusterTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/KafkaClusterTest.java
@@ -70,9 +70,17 @@ class KafkaClusterTest {
     private KeytoolCertificateGenerator brokerKeytoolCertificateGenerator;
     private KeytoolCertificateGenerator clientKeytoolCertificateGenerator;
 
-    @ParameterizedTest
-    @ValueSource(booleans = { true, false })
-    void kafkaCluster(boolean kraft) throws Exception {
+    @Test
+    void zookeeperKafkaCluster() throws Exception {
+        kafkaCluster(false);
+    }
+
+    @Test
+    void kraftKafkaCluster() throws Exception {
+        kafkaCluster(true);
+    }
+
+    private void kafkaCluster(boolean kraft) throws Exception {
         try (var cluster = KafkaClusterFactory.create(KafkaClusterConfig.builder()
                 .testInfo(testInfo)
                 .kraftMode(kraft)

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/KafkaClusterTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/KafkaClusterTest.java
@@ -47,7 +47,6 @@ import io.kroxylicious.testing.kafka.common.KafkaClusterConfig;
 import io.kroxylicious.testing.kafka.common.KafkaClusterFactory;
 import io.kroxylicious.testing.kafka.common.KeytoolCertificateGenerator;
 import io.kroxylicious.testing.kafka.common.Utils;
-import io.kroxylicious.testing.kafka.testcontainers.TestcontainersKafkaCluster;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -336,7 +335,6 @@ class KafkaClusterTest {
                 .saslMechanism(mechanism)
                 .user("guest", "pass")
                 .build())) {
-            assumeThat(scramSupportedByCluster(cluster, kraft)).isTrue();
             cluster.start();
             verifyRecordRoundTrip(1, cluster);
         }
@@ -361,7 +359,8 @@ class KafkaClusterTest {
                 .jaasClientOption("unsecuredLoginStringClaim_sub", "principal")
                 .jaasServerOption("unsecuredLoginStringClaim_sub", "principal")
                 .build())) {
-            assumeThat(scramSupportedByCluster(cluster, kraft)).isTrue();
+            // https://github.com/ozangunalp/kafka-native/issues/181
+            assumeThat(true).isTrue();
             cluster.start();
             verifyRecordRoundTrip(1, cluster);
         }
@@ -532,6 +531,7 @@ class KafkaClusterTest {
      * Pings the cluster in order to assert connectivity. We don't care about the result.
      * @param admin admin
      */
+    @SuppressWarnings("java:S1481") // making clear the intent that the result of the operation is unneeded.
     private void performClusterOperation(Admin admin) {
         var unused = admin.describeCluster().nodes().toCompletionStage().toCompletableFuture().join();
     }
@@ -547,8 +547,4 @@ class KafkaClusterTest {
         this.clientKeytoolCertificateGenerator.generateSelfSignedCertificateEntry("clientTest@kroxylicious.io", "client", "Dev", "Kroxylicious.ip", null, null, "US");
     }
 
-    private boolean scramSupportedByCluster(KafkaCluster cluster, boolean kraft) {
-        // https://github.com/ozangunalp/kafka-native/issues/181
-        return !(cluster instanceof TestcontainersKafkaCluster && kraft);
-    }
 }

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/TemplateTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/TemplateTest.java
@@ -19,7 +19,6 @@ import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.UnsupportedVersionException;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.TestInstance;
@@ -32,6 +31,8 @@ import org.junit.jupiter.api.extension.ParameterResolutionException;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContext;
 import org.junit.jupiter.api.extension.TestTemplateInvocationContextProvider;
 import org.junit.jupiter.api.extension.support.TypeBasedParameterResolver;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.common.BrokerCluster;
@@ -238,7 +239,7 @@ class TemplateTest {
                     getTestTemplateInvocationContext("two"));
         }
 
-        @NotNull
+        @NonNull
         private TestTemplateInvocationContext getTestTemplateInvocationContext(String value) {
             return new TestTemplateInvocationContext() {
                 @Override


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Allow test Kafka Clusters to use SASL SCRAM-SHA and OAUTH bearer.

This PR just refactors the KafkaCluster API.  The annotation API will be refactored by a separate PR.

### Additional Context

Motivation is to allow an integration test to be written to support the SASL OAUTHBEARER filter work going on in the main project.  SCRAM support, whilst not strictly required, is being considered too in order to ensure a cohesive API results.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
