### PR TITLE
Create SCRAM users in advance of cluster startup

### DIFF
--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/KraftLogDirUtil.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/KraftLogDirUtil.java
@@ -26,6 +26,7 @@ import scala.collection.immutable.Seq;
  */
 final class KraftLogDirUtil {
     private static final PrintStream LOGGING_PRINT_STREAM = LoggingPrintStream.loggingPrintStream(InVMKafkaCluster.LOGGER, System.Logger.Level.DEBUG);
+    private static final String FORMAT_METHOD_NAME = "formatCommand";
     private static final boolean IGNORE_FORMATTED = true;
 
     private KraftLogDirUtil() {
@@ -53,12 +54,21 @@ final class KraftLogDirUtil {
 
     private static void formatReflectively(Object metaProperties, Seq<String> directories, BootstrapMetadata bootstrapMetadata, MetadataVersion metadataVersion)
             throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
-        var formatMethod = StorageTool.class.getDeclaredMethod("formatCommand", PrintStream.class, Seq.class, metaProperties.getClass(), BootstrapMetadata.class,
-                MetadataVersion.class,
-                boolean.class);
-        // note ignoreFormatter=true so tolerate a log directory which is already formatted. this is
-        // required to support start/stop.
-        formatMethod.invoke(null, LOGGING_PRINT_STREAM, directories, metaProperties, bootstrapMetadata, metadataVersion, IGNORE_FORMATTED);
+        try {
+            var formatMethod = StorageTool.class.getDeclaredMethod(FORMAT_METHOD_NAME, PrintStream.class, Seq.class, metaProperties.getClass(), BootstrapMetadata.class,
+                    MetadataVersion.class,
+                    boolean.class);
+            // note ignoreFormatter=true so tolerate a log directory which is already formatted. this is
+            // required to support start/stop.
+            formatMethod.invoke(null, LOGGING_PRINT_STREAM, directories, metaProperties, bootstrapMetadata, metadataVersion, IGNORE_FORMATTED);
+        }
+        catch (NoSuchMethodException e) {
+            // fallback for pre-kafka 3.6 formatCommand which didn't accept BootstrapMetadata
+            var formatMethod = StorageTool.class.getDeclaredMethod(FORMAT_METHOD_NAME, PrintStream.class, Seq.class, metaProperties.getClass(),
+                    MetadataVersion.class,
+                    boolean.class);
+            formatMethod.invoke(null, LOGGING_PRINT_STREAM, directories, metaProperties, metadataVersion, IGNORE_FORMATTED);
+        }
     }
 
     private static BootstrapMetadata buildBootstrapMetadata(List<UserScramCredentialRecord> scramCredentialRecords, MetadataVersion metadataVersion) {

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/KraftLogDirUtil.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/KraftLogDirUtil.java
@@ -26,6 +26,7 @@ import scala.collection.immutable.Seq;
  */
 final class KraftLogDirUtil {
     private static final PrintStream LOGGING_PRINT_STREAM = LoggingPrintStream.loggingPrintStream(InVMKafkaCluster.LOGGER, System.Logger.Level.DEBUG);
+    private static final boolean IGNORE_FORMATTED = true;
 
     private KraftLogDirUtil() {
         throw new IllegalStateException();
@@ -57,7 +58,7 @@ final class KraftLogDirUtil {
                 boolean.class);
         // note ignoreFormatter=true so tolerate a log directory which is already formatted. this is
         // required to support start/stop.
-        formatMethod.invoke(null, LOGGING_PRINT_STREAM, directories, metaProperties, bootstrapMetadata, metadataVersion, true);
+        formatMethod.invoke(null, LOGGING_PRINT_STREAM, directories, metaProperties, bootstrapMetadata, metadataVersion, IGNORE_FORMATTED);
     }
 
     private static BootstrapMetadata buildBootstrapMetadata(List<UserScramCredentialRecord> scramCredentialRecords, MetadataVersion metadataVersion) {

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/KraftLogDirUtil.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/KraftLogDirUtil.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.testing.kafka.invm;
+
+import java.io.PrintStream;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.kafka.common.metadata.FeatureLevelRecord;
+import org.apache.kafka.common.metadata.UserScramCredentialRecord;
+import org.apache.kafka.common.protocol.ApiMessage;
+import org.apache.kafka.metadata.bootstrap.BootstrapMetadata;
+import org.apache.kafka.server.common.ApiMessageAndVersion;
+import org.apache.kafka.server.common.MetadataVersion;
+
+import kafka.server.KafkaConfig;
+import kafka.tools.StorageTool;
+import scala.collection.immutable.Seq;
+
+/**
+ * Note that this code is base on code from Kafka's StorageTool.
+ */
+final class KraftLogDirUtil {
+    private static final PrintStream LOGGING_PRINT_STREAM = LoggingPrintStream.loggingPrintStream(InVMKafkaCluster.LOGGER, System.Logger.Level.DEBUG);
+
+    private KraftLogDirUtil() {
+        throw new IllegalStateException();
+    }
+
+    static void prepareLogDirsForKraft(String clusterId, KafkaConfig config, List<UserScramCredentialRecord> scramCredentialRecords) {
+        var directories = StorageTool.configToLogDirectories(config);
+        try {
+            // Default the metadata version from the IBP version specified in config in the same way as kafka.tools.StorageTool.
+            var metadataVersion = MetadataVersion.fromVersionString(
+                    config.interBrokerProtocolVersionString() == null ? MetadataVersion.LATEST_PRODUCTION.version() : config.interBrokerProtocolVersionString());
+
+            // in kafka 3.7.0 the MetadataProperties class moved package, we use reflection to enable the extension to work with
+            // the old and new class.
+            var metaProperties = buildMetadataPropertiesReflectively(clusterId, config);
+            var bootstrapMetadata = buildBootstrapMetadata(scramCredentialRecords, metadataVersion);
+
+            formatReflectively(metaProperties, directories, bootstrapMetadata, metadataVersion);
+        }
+        catch (Exception e) {
+            throw new RuntimeException("failed to prepare log dirs for KRaft", e);
+        }
+    }
+
+    private static void formatReflectively(Object metaProperties, Seq<String> directories, BootstrapMetadata bootstrapMetadata, MetadataVersion metadataVersion)
+            throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+        var formatMethod = StorageTool.class.getDeclaredMethod("formatCommand", PrintStream.class, Seq.class, metaProperties.getClass(), BootstrapMetadata.class,
+                MetadataVersion.class,
+                boolean.class);
+        // note ignoreFormatter=true so tolerate a log directory which is already formatted. this is
+        // required to support start/stop.
+        formatMethod.invoke(null, LOGGING_PRINT_STREAM, directories, metaProperties, bootstrapMetadata, metadataVersion, true);
+    }
+
+    private static BootstrapMetadata buildBootstrapMetadata(List<UserScramCredentialRecord> scramCredentialRecords, MetadataVersion metadataVersion) {
+        var metadataRecords = new ArrayList<ApiMessageAndVersion>();
+        metadataRecords.add(metadataVersionMessage(metadataVersion));
+        for (var credentialRecord : scramCredentialRecords) {
+            metadataRecords.add(scramMessage(credentialRecord));
+        }
+        return BootstrapMetadata.fromRecords(metadataRecords, InVMKafkaCluster.INVM_KAFKA);
+    }
+
+    private static Object buildMetadataPropertiesReflectively(String clusterId, KafkaConfig config)
+            throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+        var buildMetadataProperties = StorageTool.class.getDeclaredMethod("buildMetadataProperties", String.class, KafkaConfig.class);
+        return buildMetadataProperties.invoke(null, clusterId, config);
+    }
+
+    private static ApiMessageAndVersion withVersion(ApiMessage message) {
+        return new ApiMessageAndVersion(message, (short) 0);
+    }
+
+    private static ApiMessageAndVersion metadataVersionMessage(MetadataVersion metadataVersion) {
+        return withVersion(new FeatureLevelRecord().setName(MetadataVersion.FEATURE_NAME).setFeatureLevel(metadataVersion.featureLevel()));
+    }
+
+    private static ApiMessageAndVersion scramMessage(UserScramCredentialRecord scramRecord) {
+        return withVersion(scramRecord);
+    }
+}

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/ScramUtils.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/ScramUtils.java
@@ -5,8 +5,15 @@
  */
 package io.kroxylicious.testing.kafka.invm;
 
+import java.util.List;
+import java.util.Map;
+
 import org.apache.kafka.common.metadata.UserScramCredentialRecord;
 import org.apache.kafka.common.security.scram.ScramCredential;
+import org.apache.kafka.common.security.scram.internals.ScramMechanism;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import kafka.tools.StorageTool;
 
 final class ScramUtils {
 
@@ -16,5 +23,23 @@ final class ScramUtils {
 
     static ScramCredential asScramCredential(UserScramCredentialRecord uscr) {
         return new ScramCredential(uscr.salt(), uscr.storedKey(), uscr.serverKey(), uscr.iterations());
+    }
+
+    @NonNull
+    static List<UserScramCredentialRecord> getScramCredentialRecords(String saslMechanism, Map<String, String> users) {
+        var scramMechanism = ScramMechanism.forMechanismName(saslMechanism);
+        if (scramMechanism == null) {
+            throw new IllegalArgumentException("unexpected scram mechanism " + saslMechanism);
+        }
+        return users
+                .entrySet()
+                .stream()
+                .map(e -> StorageTool.getUserScramCredentialRecord(scramMechanism.mechanismName(), toKafkaScramCredentialsFormat(e.getKey(), e.getValue())))
+                .toList();
+    }
+
+    @NonNull
+    private static String toKafkaScramCredentialsFormat(String username, String password) {
+        return "[name=%s,password=%s]".formatted(username, password);
     }
 }

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/ScramUtils.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/ScramUtils.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.testing.kafka.invm;
+
+import org.apache.kafka.common.metadata.UserScramCredentialRecord;
+import org.apache.kafka.common.security.scram.ScramCredential;
+
+final class ScramUtils {
+
+    private ScramUtils() {
+        throw new IllegalStateException();
+    }
+
+    static ScramCredential asScramCredential(UserScramCredentialRecord uscr) {
+        return new ScramCredential(uscr.salt(), uscr.storedKey(), uscr.serverKey(), uscr.iterations());
+    }
+}

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/invm/ScramUtilsTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/invm/ScramUtilsTest.java
@@ -6,12 +6,14 @@
 package io.kroxylicious.testing.kafka.invm;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
 
 import org.apache.kafka.common.metadata.UserScramCredentialRecord;
 import org.apache.kafka.common.security.scram.ScramCredential;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class ScramUtilsTest {
     @Test
@@ -28,6 +30,21 @@ class ScramUtilsTest {
         assertThat(sc).extracting(ScramCredential::iterations).isEqualTo(iterations);
         assertThat(sc).extracting(ScramCredential::salt).isEqualTo(salt);
         assertThat(sc).extracting(ScramCredential::serverKey).isEqualTo(server);
+    }
 
+    @Test
+    void generateCredentialsRecordsForSingleUser() {
+        var recs = ScramUtils.getScramCredentialRecords("SCRAM-SHA-256", Map.of("alice", "pass"));
+        assertThat(recs)
+                .singleElement()
+                .extracting(UserScramCredentialRecord::name)
+                .isEqualTo("alice");
+    }
+
+    @Test
+    void noneScramMechanismRejected() {
+        var users = Map.<String, String> of();
+        assertThatThrownBy(() -> ScramUtils.getScramCredentialRecords("PLAIN", users))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/invm/ScramUtilsTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/invm/ScramUtilsTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.testing.kafka.invm;
+
+import java.nio.charset.StandardCharsets;
+
+import org.apache.kafka.common.metadata.UserScramCredentialRecord;
+import org.apache.kafka.common.security.scram.ScramCredential;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ScramUtilsTest {
+    @Test
+    void asScramCredential() {
+        int iterations = 4096;
+        byte[] salt = "salt".getBytes(StandardCharsets.UTF_8);
+        byte[] server = "key".getBytes(StandardCharsets.UTF_8);
+        var uscr = new UserScramCredentialRecord()
+                .setIterations(iterations)
+                .setSalt(salt)
+                .setServerKey(server);
+
+        var sc = ScramUtils.asScramCredential(uscr);
+        assertThat(sc).extracting(ScramCredential::iterations).isEqualTo(iterations);
+        assertThat(sc).extracting(ScramCredential::salt).isEqualTo(salt);
+        assertThat(sc).extracting(ScramCredential::serverKey).isEqualTo(server);
+
+    }
+}


### PR DESCRIPTION

### Type of change

_Select the type of your PR_

- Bugfix

### Description

Why: avoid race condition that lead to sporadic authentication failures during tests involving SCRAM users.

During development of #330 I was noticing occasional sporadic test fails in KRaft mode with SCRAM users.  The client
would fail with a authentication error.  I reason that the creating SCRAM users via the Admin client does not give the
guarantee that the user is immediately available for authentication (indeed, introducing non-viable  a Thread.sleep() worked around the issue).

Prepopulating the SCRAM users before startup seems like the best way to eliminate the issue.


### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
