### PR TITLE
Enable zk with out kafka cluster

### DIFF
--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
@@ -141,7 +141,7 @@ public class KafkaClusterConfig {
     @Singular
     private final Map<String, String> brokerConfigs;
 
-    @SuppressWarnings("java:S5738") // silence warnings about the use of deprecated code
+    @SuppressWarnings({ "java:S5738", "removal" }) // silence warnings about the use of deprecated code
     private static final Set<Class<? extends Annotation>> SUPPORTED_CONSTRAINTS = Set.of(
             ClusterId.class,
             BrokerCluster.class,

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
@@ -482,12 +482,12 @@ public class InVMKafkaCluster implements KafkaCluster, KafkaClusterConfig.KafkaE
                 var adminZkClient = new AdminZkClient(zkClient, Option.empty());
                 var userEntityType = "users";
                 disableControllerCheck(zkClient);
-                parsedCredentials.forEach(uscr -> {
-                    var userConfig = adminZkClient.fetchEntityConfig(userEntityType, uscr.name());
-                    var credentialsString = ScramCredentialUtils.credentialToString(ScramUtils.asScramCredential(uscr));
+                parsedCredentials.forEach(credentials -> {
+                    var userConfig = adminZkClient.fetchEntityConfig(userEntityType, credentials.name());
+                    var credentialsString = ScramCredentialUtils.credentialToString(ScramUtils.asScramCredential(credentials));
 
-                    userConfig.setProperty(ScramMechanism.fromType(uscr.mechanism()).mechanismName(), credentialsString);
-                    adminZkClient.changeConfigs(userEntityType, uscr.name(), userConfig, false);
+                    userConfig.setProperty(ScramMechanism.fromType(credentials.mechanism()).mechanismName(), credentialsString);
+                    adminZkClient.changeConfigs(userEntityType, credentials.name(), userConfig, false);
                 });
             }
         }

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <lombok.version>1.18.32</lombok.version>
         <assertj-core.version>3.26.0</assertj-core.version>
         <spotbugs-annotations.version>4.8.6</spotbugs-annotations.version>
-        <zookeeper.version>3.8.3</zookeeper.version>
+        <zookeeper.version>3.8.4</zookeeper.version>
         <log4j.version>2.23.1</log4j.version>
         <awaitility.version>4.2.1</awaitility.version>
         <duct-tape.version>1.0.8</duct-tape.version>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <skipUTs>${skipTests}</skipUTs>
 
         <junit.version>5.10.3</junit.version>
-        <kafka.version>3.7.0</kafka.version>
+        <kafka.version>3.7.1</kafka.version>
         <testcontainers.version>1.19.8</testcontainers.version>
         <lombok.version>1.18.32</lombok.version>
         <assertj-core.version>3.26.0</assertj-core.version>


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Use reflection hackery to force `enableEntityConfigControllerCheck` to false. 

### Additional Context

We can't configure SCRAM users before starting Kafka without this.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
