### PR TITLE
Remove the now redundant dependency management of byte-buddy.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,8 +99,6 @@
         <moby-names-generator.version>20.10.1-r0</moby-names-generator.version>
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
 
-        <!-- Required for JDK 21 compatibility, remove dependency management for byte-buddy once assertj bumps to a newer bytebuddy -->
-        <byte-buddy.version>1.14.18</byte-buddy.version>
         <!-- Avoids issues with ryuk when running with podman https://github.com/containers/podman/issues/7927#issuecomment-731525556 -->
         <testcontainers.ryuk.disabled>true</testcontainers.ryuk.disabled>
     </properties>
@@ -238,13 +236,6 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <dependency>
-                <groupId>net.bytebuddy</groupId>
-                <artifactId>byte-buddy</artifactId>
-                <version>${byte-buddy.version}</version>
-                <scope>test</scope>
-            </dependency>
-
             <dependency>
                 <groupId>info.schnatterer.moby-names-generator</groupId>
                 <artifactId>moby-names-generator</artifactId>


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring

### Description

Remove the now redundant dependency management of byte-buddy.

why: we are already using a newer version of assertj that has the new dependency.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
