### PR TITLE
Fix #378: Fix unsafe publication to HashMap used to track running kafka brokers.

### DIFF
--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
@@ -18,13 +18,14 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.IntPredicate;
@@ -75,9 +76,8 @@ public class InVMKafkaCluster implements KafkaCluster, KafkaClusterConfig.KafkaE
 
     /**
      * Map of kafka <code>node.id</code> to {@link Server}.
-     * Protected by lock of {@link InVMKafkaCluster itself.}
      */
-    private final Map<Integer, Server> servers = new HashMap<>();
+    private final ConcurrentMap<Integer, Server> servers = new ConcurrentHashMap<>();
 
     /**
      * Set of kafka <code>node.id</code> that are currently stopped.


### PR DESCRIPTION

### Type of change

_Select the type of your PR_

- Bugfix

### Description

Fix unsafe publication to HashMap used to track running kafka brokers.

why: Kafka servers are started in parallel (by design) but the data structure used to track the servers was not thread safe. This probably accounts for the accounting error spotted in #378.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
