### PR TITLE
Remove unused site plugin declaration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -367,11 +367,6 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-site-plugin</artifactId>
-                    <version>3.20.0</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>3.5.2</version>
                     <configuration>
@@ -498,7 +493,8 @@
                                             <banLatest>true</banLatest>
                                             <banRelease>true</banRelease>
                                             <banSnapshots>false</banSnapshots>
-                                            <phases>clean,deploy,site</phases>
+                                            <phases>clean,deploy</phases>
+                                            <unCheckedPluginList>org.apache.maven.plugins:maven-site-plugin</unCheckedPluginList>
                                         </requirePluginVersions>
                                     </rules>
                                 </configuration>


### PR DESCRIPTION
### Type of change

- Refactoring

### Description

Remove unused plugin so we do not have to maintain it via dependabot

Note that it seems to be detected as an active plugin by the enforcer despite apparently contributing no invocations to a maven install or deploy, so we exclude it from the enforcement.