### PR TITLE
Refactor endpoint creation and allow client connections to be formed to controllers in container mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Please enumerate all user-facing changes using format `<githib issue/pr number>:
 ## 1.0.0
 
 ## SNAPSHOT
+
+* [##419](https://github.com/kroxylicious/kroxylicious-junit5-extension/pull/#419): Refactor endpoint creation and allow client connections to be formed to controllers in container mode.
+* [##417](https://github.com/kroxylicious/kroxylicious-junit5-extension/pull/#417): Bump kafka.version from 3.8.0 to 3.9.0
+
 ## 0.9.1
 
 * [#365](https://github.com/kroxylicious/kroxylicious-junit5-extension/pull/365): Bump kafka.version from 3.7.1 to 3.8.0

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
@@ -476,8 +476,8 @@ public class KafkaClusterConfig {
     private static void configureInternalListener(TreeMap<String, String> protocolMap, TreeMap<String, String> listeners, KafkaListener interBrokerEndpoint,
                                                   TreeMap<String, String> advertisedListeners, TreeSet<String> earlyStart, Properties server) {
         protocolMap.put(INTERNAL_LISTENER_NAME, SecurityProtocol.PLAINTEXT.name());
-        listeners.put(INTERNAL_LISTENER_NAME, interBrokerEndpoint.bind().toString());
-        advertisedListeners.put(INTERNAL_LISTENER_NAME, interBrokerEndpoint.advertised().toString());
+        listeners.put(INTERNAL_LISTENER_NAME, interBrokerEndpoint.bind().address());
+        advertisedListeners.put(INTERNAL_LISTENER_NAME, interBrokerEndpoint.advertised().address());
         earlyStart.add(INTERNAL_LISTENER_NAME);
         putConfig(server, "inter.broker.listener.name", INTERNAL_LISTENER_NAME);
     }
@@ -485,21 +485,21 @@ public class KafkaClusterConfig {
     private static void configureAnonListener(TreeMap<String, String> protocolMap, TreeMap<String, String> listeners, KafkaListener anonEndpoint,
                                               TreeMap<String, String> advertisedListeners) {
         protocolMap.put(ANON_LISTENER_NAME, SecurityProtocol.PLAINTEXT.name());
-        listeners.put(ANON_LISTENER_NAME, anonEndpoint.bind().toString());
-        advertisedListeners.put(ANON_LISTENER_NAME, anonEndpoint.advertised().toString());
+        listeners.put(ANON_LISTENER_NAME, anonEndpoint.bind().address());
+        advertisedListeners.put(ANON_LISTENER_NAME, anonEndpoint.advertised().address());
     }
 
     private static void configureExternalListener(TreeMap<String, String> protocolMap, String externalListenerTransport, TreeMap<String, String> listeners,
                                                   KafkaListener clientEndpoint, TreeMap<String, String> advertisedListeners) {
         protocolMap.put(EXTERNAL_LISTENER_NAME, externalListenerTransport);
-        listeners.put(EXTERNAL_LISTENER_NAME, clientEndpoint.bind().toString());
-        advertisedListeners.put(EXTERNAL_LISTENER_NAME, clientEndpoint.advertised().toString());
+        listeners.put(EXTERNAL_LISTENER_NAME, clientEndpoint.bind().address());
+        advertisedListeners.put(EXTERNAL_LISTENER_NAME, clientEndpoint.advertised().address());
     }
 
     private static void configureLegacyNode(KafkaListenerSource kafkaListenerSource, ConfigHolder configHolder) {
         KafkaListener kafkaListener = kafkaListenerSource.getKafkaListener(Listener.CONTROLLER, 0);
         var server = configHolder.properties();
-        putConfig(server, "zookeeper.connect", kafkaListener.kafkaNet().toString());
+        putConfig(server, "zookeeper.connect", kafkaListener.kafkaNet().address());
         putConfig(server, "zookeeper.sasl.enabled", "false");
         putConfig(server, "zookeeper.connection.timeout.ms", Long.toString(60000));
         putConfig(server, "zookeeper.session.timeout.ms", Long.toString(6000));
@@ -516,7 +516,7 @@ public class KafkaClusterConfig {
 
         var quorumVoters = IntStream.range(0, kraftControllers)
                 .mapToObj(controllerId -> String.format("%d@%s", controllerId,
-                        kafkaListenerSource.getKafkaListener(Listener.CONTROLLER, controllerId).kafkaNet()))
+                        kafkaListenerSource.getKafkaListener(Listener.CONTROLLER, controllerId).kafkaNet().address()))
                 .collect(Collectors.joining(","));
         putConfig(nodeConfiguration, "controller.quorum.voters", quorumVoters);
         putConfig(nodeConfiguration, "controller.listener.names", CONTROLLER_LISTENER_NAME);
@@ -525,10 +525,10 @@ public class KafkaClusterConfig {
         putConfig(nodeConfiguration, "process.roles", configHolder.roles());
         if (configHolder.isController()) {
             var controllerEndpoint = kafkaListenerSource.getKafkaListener(Listener.CONTROLLER, configHolder.nodeId());
-            listeners.put(CONTROLLER_LISTENER_NAME, controllerEndpoint.bind().toString());
+            listeners.put(CONTROLLER_LISTENER_NAME, controllerEndpoint.bind().address());
             earlyStart.add(CONTROLLER_LISTENER_NAME);
             if (!PRE_KAFKA_39.matcher(getKafkaVersion()).matches()) {
-                advertisedListeners.put(CONTROLLER_LISTENER_NAME, controllerEndpoint.advertised().toString());
+                advertisedListeners.put(CONTROLLER_LISTENER_NAME, controllerEndpoint.advertised().address());
             }
         }
     }

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
@@ -335,10 +335,7 @@ public class KafkaClusterConfig {
         putConfig(nodeConfiguration, "listener.security.protocol.map", formatListeners(protocolMap, ":"));
         putConfig(nodeConfiguration, "listeners", formatListeners(listeners, "://"));
         putConfig(nodeConfiguration, "early.start.listeners", String.join(",", earlyStart));
-        if (!advertisedListeners.isEmpty()) {
-            putConfig(nodeConfiguration, "advertised.listeners", formatListeners(advertisedListeners, "://"));
-
-        }
+        putConfig(nodeConfiguration, "advertised.listeners", formatListeners(advertisedListeners, "://"));
 
         configureSasl(nodeConfiguration);
 

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
@@ -364,7 +364,7 @@ public class KafkaClusterConfig {
 
     @NonNull
     private ConfigHolder configureController(int nodeId, Properties nodeConfiguration) {
-        return new ConfigHolder(nodeConfiguration, null, null,
+        return new ConfigHolder(nodeConfiguration,
                 nodeId, kafkaKraftClusterId);
     }
 
@@ -385,7 +385,7 @@ public class KafkaClusterConfig {
         configureInternalListener(protocolMap, listeners, interBrokerEndpoint, advertisedListeners, earlyStart, nodeConfiguration);
         configureAnonListener(protocolMap, listeners, anonEndpoint, advertisedListeners);
         configureTls(clientEndpoint, nodeConfiguration);
-        return new ConfigHolder(nodeConfiguration, clientEndpoint.advertised().port(), anonEndpoint.advertised().port(),
+        return new ConfigHolder(nodeConfiguration,
                 nodeId, kafkaKraftClusterId);
     }
 
@@ -525,7 +525,8 @@ public class KafkaClusterConfig {
         putConfig(nodeConfiguration, "node.id", Integer.toString(nodeId)); // Required by Kafka 3.3 onwards.
 
         var quorumVoters = IntStream.range(0, kraftControllers)
-                .mapToObj(controllerId -> String.format("%d@%s", controllerId, kafkaListenerSource.getKafkaListener(Listener.CONTROLLER, controllerId).kafkaNet().toString()))
+                .mapToObj(controllerId -> String.format("%d@%s", controllerId,
+                        kafkaListenerSource.getKafkaListener(Listener.CONTROLLER, controllerId).kafkaNet().toString()))
                 .collect(Collectors.joining(","));
         putConfig(nodeConfiguration, "controller.quorum.voters", quorumVoters);
         putConfig(nodeConfiguration, "controller.listener.names", CONTROLLER_LISTENER_NAME);
@@ -739,14 +740,10 @@ public class KafkaClusterConfig {
      * The type Config holder.
      *
      * @param properties          the properties
-     * @param externalPort        the external port
-     * @param anonPort            the anon port
      * @param brokerNum           the broker num
      * @param kafkaKraftClusterId the kafka kraft cluster id
      */
     public record ConfigHolder(Properties properties,
-                               Integer externalPort,
-                               Integer anonPort,
                                int brokerNum,
                                String kafkaKraftClusterId) {
         private String getRoles() {

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaEndpoint.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaEndpoint.java
@@ -5,10 +5,9 @@
  */
 package io.kroxylicious.testing.kafka.common;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
-
 import java.util.Objects;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * The type Endpoint.

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaEndpoint.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaEndpoint.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.testing.kafka.common;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import java.util.Objects;
+
+
+/**
+ * The type Endpoint.
+ *
+ * @param host the host
+ * @param port the port
+ */
+public record KafkaEndpoint(@NonNull String host, int port) {
+    public KafkaEndpoint {
+        Objects.requireNonNull(host);
+    }
+
+    /**
+     * kafka formatted address suitable for use in configuration.
+     * @return kafka formatted address suitable for use in configuration.
+     */
+    @Override
+    public String toString() {
+        return host + ":" + port;
+    }
+
+}

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaEndpoint.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaEndpoint.java
@@ -24,9 +24,7 @@ public record KafkaEndpoint(@NonNull String host, int port) {
      * kafka formatted address suitable for use in configuration.
      * @return kafka formatted address suitable for use in configuration.
      */
-    @Override
-    public String toString() {
+    public String address() {
         return host + ":" + port;
     }
-
 }

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaListener.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaListener.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.testing.kafka.common;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import lombok.Builder;
+
+import java.util.Objects;
+
+/**
+ * The type Kafka Listener.
+ *
+ * @param bind       the bind address
+ * @param kafkaNet   the connect address within the kafka network
+ * @param advertised the connect address from the client network
+ */
+@Builder
+public record KafkaListener(@NonNull KafkaEndpoint bind, @NonNull KafkaEndpoint kafkaNet, @NonNull KafkaEndpoint advertised) {
+
+    public KafkaListener {
+        Objects.requireNonNull(bind);
+        Objects.requireNonNull(kafkaNet);
+        Objects.requireNonNull(advertised);
+    }
+
+    public static KafkaListener build(int port, String bindAddress, String host) {
+        var bind = new KafkaEndpoint(bindAddress, port);
+        var advertised = new KafkaEndpoint(host, port);
+        return new KafkaListener(bind, advertised, advertised);
+    }
+
+    public static KafkaListener build(int containerPort, String bindAddress, String containerHost, int externalPort, String clientHost) {
+        var bind = new KafkaEndpoint(bindAddress, containerPort);
+        var container = new KafkaEndpoint(containerHost, containerPort);
+        var advertised = new KafkaEndpoint(clientHost, externalPort);
+        return new KafkaListener(bind, container, advertised);
+    }
+
+}

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaListener.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaListener.java
@@ -5,10 +5,9 @@
  */
 package io.kroxylicious.testing.kafka.common;
 
-import edu.umd.cs.findbugs.annotations.NonNull;
-import lombok.Builder;
-
 import java.util.Objects;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * The type Kafka Listener.
@@ -17,7 +16,6 @@ import java.util.Objects;
  * @param kafkaNet   the connect address within the kafka network
  * @param advertised the connect address from the client network
  */
-@Builder
 public record KafkaListener(@NonNull KafkaEndpoint bind, @NonNull KafkaEndpoint kafkaNet, @NonNull KafkaEndpoint advertised) {
 
     public KafkaListener {

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaListenerSource.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaListenerSource.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package io.kroxylicious.testing.kafka.common;
 
 /**

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaListenerSource.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaListenerSource.java
@@ -1,0 +1,39 @@
+package io.kroxylicious.testing.kafka.common;
+
+/**
+ * The interface Kafka endpoints.
+ */
+public interface KafkaListenerSource {
+
+    /**
+     * Enumeration of kafka listeners used by the test harness.
+     */
+    enum Listener {
+        /**
+         * used for communications to/from consumers/producers optionally with authentication
+         */
+        EXTERNAL,
+        /**
+         * used for communications to/from consumers/producers without authentication primarily for the extension to validate the cluster
+         */
+        ANON,
+        /**
+         * used for inter-broker communications (always no auth)
+         */
+        INTERNAL,
+        /**
+         * used for inter-broker controller communications (kraft - always no auth)
+         */
+        CONTROLLER
+    }
+
+    /**
+     * Gets the kafka listen for the given listener and nodeId.
+     *
+     * @param listener listener
+     * @param nodeId   kafka <code>node.id</code>
+     * @return kafka listener.
+     */
+    KafkaListener getKafkaListener(Listener listener, int nodeId);
+
+}

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/PortAllocator.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/PortAllocator.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import io.kroxylicious.testing.kafka.common.KafkaClusterConfig.KafkaEndpoints.Listener;
+import io.kroxylicious.testing.kafka.common.KafkaListenerSource.Listener;
 
 /**
  * Allocates ports to a <code>listener</code> and <code>node.id</code> tuple.

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
@@ -278,7 +278,7 @@ public class InVMKafkaCluster implements KafkaCluster, KafkaListenerSource, Admi
         return servers.keySet().stream()
                 .filter(nodePredicate)
                 .map(nodeId -> getKafkaListener(listener, nodeId))
-                .map(kafkaListener -> kafkaListener.advertised().toString())
+                .map(kafkaListener -> kafkaListener.advertised().address())
                 .collect(Collectors.joining(","));
     }
 

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
@@ -32,7 +32,6 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import io.kroxylicious.testing.kafka.common.KafkaListenerSource;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.ScramMechanism;
 import org.apache.kafka.common.security.scram.internals.ScramCredentialUtils;
@@ -54,8 +53,9 @@ import scala.Option;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.api.TerminationStyle;
 import io.kroxylicious.testing.kafka.clients.CloseableAdmin;
-import io.kroxylicious.testing.kafka.common.KafkaListener;
 import io.kroxylicious.testing.kafka.common.KafkaClusterConfig;
+import io.kroxylicious.testing.kafka.common.KafkaListener;
+import io.kroxylicious.testing.kafka.common.KafkaListenerSource;
 import io.kroxylicious.testing.kafka.common.PortAllocator;
 import io.kroxylicious.testing.kafka.common.Utils;
 import io.kroxylicious.testing.kafka.internal.AdminSource;

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
@@ -68,7 +68,6 @@ import static kafka.zk.KafkaZkClient.createZkClient;
 public class InVMKafkaCluster implements KafkaCluster, KafkaListenerSource, AdminSource {
     static final System.Logger LOGGER = System.getLogger(InVMKafkaCluster.class.getName());
     private static final int STARTUP_TIMEOUT = 30;
-    static final String INVM_KAFKA = "invm-kafka";
 
     private final KafkaClusterConfig clusterConfig;
     private final Path tempDirectory;
@@ -497,7 +496,7 @@ public class InVMKafkaCluster implements KafkaCluster, KafkaListenerSource, Admi
         if (!scramArguments.isEmpty()) {
             var uscrs = ScramUtils.getUserScramCredentialRecords(scramArguments);
             ZKClientConfig zkClientConfig = KafkaServer.zkClientConfigFromKafkaConfig(config, false);
-            try (var zkClient = createZkClient(INVM_KAFKA, Time.SYSTEM, config, zkClientConfig)) {
+            try (var zkClient = createZkClient("invm-kafka-zookeeper-client", Time.SYSTEM, config, zkClientConfig)) {
                 var adminZkClient = new AdminZkClient(zkClient, Option.empty());
                 var userEntityType = "users";
                 disableControllerCheck(zkClient);

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/KraftLogDirUtil.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/KraftLogDirUtil.java
@@ -113,7 +113,7 @@ final class KraftLogDirUtil {
                 .stream()
                 .map(KraftLogDirUtil::scramMessage)
                 .toList());
-        return BootstrapMetadata.fromRecords(metadataRecords, InVMKafkaCluster.INVM_KAFKA);
+        return BootstrapMetadata.fromRecords(metadataRecords, KraftLogDirUtil.class.getName());
     }
 
     private static Object buildMetadataPropertiesReflectively(String clusterId, KafkaConfig config)

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
@@ -40,7 +40,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import io.kroxylicious.testing.kafka.common.KafkaListenerSource;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.common.config.SslConfigs;
 import org.awaitility.Awaitility;
@@ -70,8 +69,9 @@ import lombok.SneakyThrows;
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
 import io.kroxylicious.testing.kafka.api.TerminationStyle;
 import io.kroxylicious.testing.kafka.clients.CloseableAdmin;
-import io.kroxylicious.testing.kafka.common.KafkaListener;
 import io.kroxylicious.testing.kafka.common.KafkaClusterConfig;
+import io.kroxylicious.testing.kafka.common.KafkaListener;
+import io.kroxylicious.testing.kafka.common.KafkaListenerSource;
 import io.kroxylicious.testing.kafka.common.PortAllocator;
 import io.kroxylicious.testing.kafka.common.Utils;
 import io.kroxylicious.testing.kafka.common.Version;

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
@@ -514,6 +514,7 @@ public class TestcontainersKafkaCluster implements Startable, KafkaCluster, Kafk
                             Thread.sleep(timeOut);
                         }
                         catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
                             throw new RuntimeException(e);
                         }
                     });

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
@@ -297,7 +297,7 @@ public class TestcontainersKafkaCluster implements Startable, KafkaCluster, Kafk
         return nodes.keySet().stream()
                 .filter(nodePredicate)
                 .map(nodeId -> getKafkaListener(listener, nodeId))
-                .map(kafkaListener -> kafkaListener.advertised().toString())
+                .map(kafkaListener -> kafkaListener.advertised().address())
                 .collect(Collectors.joining(","));
     }
 

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/KafkaClusterTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/KafkaClusterTest.java
@@ -51,14 +51,12 @@ import io.kroxylicious.testing.kafka.common.KafkaClusterConfig;
 import io.kroxylicious.testing.kafka.common.KafkaClusterFactory;
 import io.kroxylicious.testing.kafka.common.KeytoolCertificateGenerator;
 import io.kroxylicious.testing.kafka.common.Utils;
-import io.kroxylicious.testing.kafka.invm.InVMKafkaCluster;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 /**
  * Test case that simply exercises the ability to control the kafka cluster from the test.
@@ -494,7 +492,7 @@ class KafkaClusterTest {
     }
 
     /**
-     * KIP-919 tests ability to connect to the controller.bootstrap.
+     * KIP-919 tests ability for the Kafka Admin client to connect to the controller.bootstrap.
      */
     @ParameterizedTest
     @ValueSource(ints = { 1, 2 })
@@ -506,7 +504,6 @@ class KafkaClusterTest {
                 .kraftControllers(numControllers)
                 .kraftMode(true)
                 .build())) {
-            assumeTrue(cluster instanceof InVMKafkaCluster, "admin client connections to KRaft controllers not yet supported.");
             cluster.start();
 
             try (var controllerAdmin = CloseableAdmin.create(cluster.getControllerAdminClientConfiguration())) {

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfigTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfigTest.java
@@ -202,6 +202,16 @@ class KafkaClusterConfigTest {
     }
 
     @Test
+    void shouldRejectBadInvalidMechanism() {
+        // Given
+        final KafkaClusterConfig kafkaClusterConfig = kafkaClusterConfigBuilder.saslMechanism("FOO").build();
+
+        // When/Then
+        assertThatThrownBy(() -> kafkaClusterConfig.getBrokerConfigs(() -> endpointConfig))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
     void kafkaVersionDisallowsNulls() {
         assertThatThrownBy(() -> kafkaClusterConfigBuilder.kafkaVersion(null)).isInstanceOf(NullPointerException.class);
     }

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfigTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfigTest.java
@@ -49,11 +49,10 @@ class KafkaClusterConfigTest {
         final var config = kafkaClusterConfig.generateConfigForSpecificNode(endpointConfig, 0);
 
         // Then
-        assertThat(config.getBrokerNum()).isZero();
-        assertThat(config.getAnonPort()).isEqualTo(ANON_BASE_PORT);
-        assertThat(config.getExternalPort()).isEqualTo(CLIENT_BASE_PORT);
-        assertThat(config.getEndpoint()).isEqualTo("localhost:" + CLIENT_BASE_PORT);
-        assertThat(config.getProperties())
+        assertThat(config.brokerNum()).isZero();
+        assertThat(config.anonPort()).isEqualTo(ANON_BASE_PORT);
+        assertThat(config.externalPort()).isEqualTo(CLIENT_BASE_PORT);
+        assertThat(config.properties())
                 .containsEntry("node.id", "0")
                 .containsEntry("controller.quorum.voters", "0@localhost:" + CONTROLLER_BASE_PORT);
     }
@@ -111,7 +110,7 @@ class KafkaClusterConfigTest {
         var config = kafkaClusterConfig.generateConfigForSpecificNode(endpointConfig, 0);
 
         // Then
-        assertThat(config.getProperties())
+        assertThat(config.properties())
                 .containsEntry("process.roles", "broker,controller")
                 .hasEntrySatisfying("advertised.listeners", value -> {
                     assertThat(value)
@@ -130,7 +129,7 @@ class KafkaClusterConfigTest {
         var config = kafkaClusterConfig.generateConfigForSpecificNode(endpointConfig, 1);
 
         // Then
-        assertThat(config.getProperties())
+        assertThat(config.properties())
                 .containsEntry("process.roles", "broker")
                 .hasEntrySatisfying("advertised.listeners", value -> {
                     assertThat(value)
@@ -150,7 +149,7 @@ class KafkaClusterConfigTest {
         var config = kafkaClusterConfig.generateConfigForSpecificNode(endpointConfig, 1);
 
         // Then
-        assertThat(config.getProperties())
+        assertThat(config.properties())
                 .containsEntry("process.roles", "broker")
                 .hasEntrySatisfying("advertised.listeners", value -> {
                     assertThat(value)
@@ -416,20 +415,20 @@ class KafkaClusterConfigTest {
 
     private void assertNodeIdHasRole(KafkaClusterConfig kafkaClusterConfig, int nodeId, String expectedRole) {
         final var config = kafkaClusterConfig.generateConfigForSpecificNode(endpointConfig, nodeId);
-        assertThat(config.getProperties()).extracting(brokerConfig -> brokerConfig.get("process.roles")).as("nodeId: %s to have process.roles", nodeId).isEqualTo(
+        assertThat(config.properties()).extracting(brokerConfig -> brokerConfig.get("process.roles")).as("nodeId: %s to have process.roles", nodeId).isEqualTo(
                 expectedRole);
     }
 
-    static class EndpointConfig implements KafkaClusterConfig.KafkaEndpoints {
+    static class EndpointConfig implements KafkaListenerSource {
 
         @NonNull
-        private static EndpointPair generateEndpoint(int nodeId, int basePort) {
+        private static KafkaListener generateEndpoint(int nodeId, int basePort) {
             final int port = basePort + nodeId;
-            return new EndpointPair(new Endpoint("0.0.0.0", port), new Endpoint("localhost", port));
+            return new KafkaListener(new KafkaEndpoint("0.0.0.0", port), new KafkaEndpoint("localhost", port), new KafkaEndpoint("localhost", port));
         }
 
         @Override
-        public EndpointPair getEndpointPair(Listener listener, int nodeId) {
+        public KafkaListener getKafkaListener(Listener listener, int nodeId) {
             switch (listener) {
 
                 case EXTERNAL -> {

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfigTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfigTest.java
@@ -49,7 +49,7 @@ class KafkaClusterConfigTest {
         final var config = kafkaClusterConfig.generateConfigForSpecificNode(endpointConfig, 0);
 
         // Then
-        assertThat(config.brokerNum()).isZero();
+        assertThat(config.nodeId()).isZero();
         assertThat(config.properties())
                 .containsEntry("node.id", "0")
                 .containsEntry("controller.quorum.voters", "0@localhost:" + CONTROLLER_BASE_PORT)

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/common/KafkaEndpointTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/common/KafkaEndpointTest.java
@@ -12,16 +12,15 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class KafkaEndpointTest {
     @Test
-    void hostNotNull() {
+    void requiresHostNotNull() {
         assertThatThrownBy(() -> new KafkaEndpoint(null, 1234))
                 .isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    void addressFormatting() {
+    void toStringFormatAddress() {
         var ep = new KafkaEndpoint("foo", 1234);
-        assertThat(ep.toString())
-                .isEqualTo("//foo:1234");
+        assertThat(ep).hasToString("foo:1234");
     }
 
 }

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/common/KafkaEndpointTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/common/KafkaEndpointTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.testing.kafka.common;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class KafkaEndpointTest {
+    @Test
+    void hostNotNull() {
+        assertThatThrownBy(() -> new KafkaEndpoint(null, 1234))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void addressFormatting() {
+        var ep = new KafkaEndpoint("foo", 1234);
+        assertThat(ep.toString())
+                .isEqualTo("//foo:1234");
+    }
+
+}

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/common/KafkaEndpointTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/common/KafkaEndpointTest.java
@@ -18,9 +18,9 @@ class KafkaEndpointTest {
     }
 
     @Test
-    void toStringFormatAddress() {
+    void addressFormatting() {
         var ep = new KafkaEndpoint("foo", 1234);
-        assertThat(ep).hasToString("foo:1234");
+        assertThat(ep.address()).isEqualTo("foo:1234");
     }
 
 }

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/common/KafkaListenerTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/common/KafkaListenerTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.testing.kafka.common;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class KafkaListenerTest {
+
+    @Test
+    void constructorValidateArguments() {
+        var endpoint = new KafkaEndpoint("host", 1);
+        assertThatThrownBy(() -> new KafkaListener(null, endpoint, endpoint))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new KafkaListener(endpoint, null, endpoint))
+                .isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> new KafkaListener(endpoint, endpoint, null))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void buildListenerForContainer() {
+        var listener = KafkaListener.build(1234, "0.0.0.0", "container", 4321, "host");
+        assertThat(listener)
+                .returns(new KafkaEndpoint("0.0.0.0", 1234), KafkaListener::bind)
+                .returns(new KafkaEndpoint("container", 1234), KafkaListener::kafkaNet)
+                .returns(new KafkaEndpoint("host", 4321), KafkaListener::advertised);
+    }
+
+    @Test
+    void buildListenerForInVM() {
+        var listener = KafkaListener.build(1234, "0.0.0.0", "localhost");
+        assertThat(listener)
+                .returns(new KafkaEndpoint("0.0.0.0", 1234), KafkaListener::bind)
+                .returns(new KafkaEndpoint("localhost", 1234), KafkaListener::kafkaNet)
+                .returns(new KafkaEndpoint("localhost", 1234), KafkaListener::advertised);
+    }
+
+}


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature
- Refactoring

### Description

Follow up to https://github.com/kroxylicious/kroxylicious-junit5-extension/pull/417.     Allows client connections to be formed to controllers in container mode too.

The problem I faced was that `EndpointPair` was not sufficient to represent of the  requirements of the controller listener in the Container case.

1.  The address that the _client_ needs to connect to is an endpoint exposed by Docker on the host.
2. Other brokers on the cluster need to connect to controller via an address on the Docker network.

This lead me to this refactoring:

 * `KafkaEndpoints` renamed to `KafkaListenerSource` to better reflect role
 * `EndpointPair` renamed to `KafkaListener` and made responsible for bind, kafka network and advertised addresses.

I also slimmed down ConfigHolder and improved the tests.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [x] Update CHANGELOG.md
