### PR TITLE
Bug fix to promote-release

### DIFF
--- a/.github/workflows/promote_release.yaml
+++ b/.github/workflows/promote_release.yaml
@@ -109,7 +109,7 @@ jobs:
           echo "MAIN_HEAD=$(git rev-list -n 1 main)" >> $GITHUB_ENV
 
           # Get PR's view of where main ought to be.  This is two commits behind PR's head.
-          echo "PR_MAIN_REF=$(git rev-list -n 1 ${PR_BRANCH}^^)" >> $GITHUB_ENV
+          echo "PR_MAIN_REF=$(git rev-list -n 1 origin/${PR_BRANCH}^^)" >> $GITHUB_ENV
 
       - name: 'Check for PR/main divergence'
         if: ${{ inputs.command == 'promote-release' }}


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Bugfix

### Description


Promote release (get heads) failed like this:

https://github.com/kroxylicious/kroxylicious-junit5-extension/actions/runs/11970938391/job/33374714845#step:7:1

```
fatal: ambiguous argument 'release-work-0.10.0-64c4f483a8162493f2b60141^^': unknown revision or path not in the working tree.
```

The issue is the branch doesn't exist as a working branch.  It needs to be qualified with the remote name (origin).  I don't understand how this was working before.



### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
