### PR TITLE
Use reflection for all Zookeeper interactions

### DIFF
--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
@@ -508,31 +508,18 @@ public class InVMKafkaCluster implements KafkaCluster, KafkaListenerSource, Admi
     }
 
     private void changeConfigs(Object adminZkClient, String userEntityType, String name, Properties userConfig, boolean isUserClientId) {
-        try {
-            var method = adminZkClient.getClass().getMethod("changeConfigs", String.class, String.class, Properties.class, Boolean.TYPE);
-            method.invoke(adminZkClient, userEntityType, name, userConfig, isUserClientId);
-        }
-        catch (Exception e) {
-            throw new IllegalStateException("Failed to invoke changeConfigs while creating scram users", e);
-        }
+        ReflectionUtils.invokeInstanceMethod(adminZkClient, "changeConfigs", userEntityType, name, userConfig, isUserClientId);
     }
 
     private Properties fetchEntityConfig(Object adminZkClient, String userEntityType, String name) {
-        try {
-            var method = adminZkClient.getClass().getMethod("fetchEntityConfig", String.class, String.class);
-            return (Properties) method.invoke(adminZkClient, userEntityType, name);
-        }
-        catch (Exception e) {
-            throw new IllegalStateException("Failed to invoke fetchEntityConfig while creating scram users", e);
-        }
-
+        return ReflectionUtils.invokeInstanceMethod(adminZkClient, "fetchEntityConfig", userEntityType, name);
     }
 
     private AutoCloseable createZkClient(String name, Time system, KafkaConfig config, ZKClientConfig zkClientConfig) {
+
         try {
             var clazz = Class.forName("kafka.zk.KafkaZkClient");
-            var createZkClientMethod = clazz.getDeclaredMethod("createZkClient", String.class, Time.class, KafkaConfig.class, ZKClientConfig.class);
-            return (AutoCloseable) createZkClientMethod.invoke(null, name, system, config, zkClientConfig);
+            return ReflectionUtils.invokeStaticMethod(clazz, "createZkClient", name, system, config, zkClientConfig);
         }
         catch (Exception e) {
             throw new IllegalStateException("Failed to invoke createZkClient while creating scram users", e);
@@ -540,13 +527,7 @@ public class InVMKafkaCluster implements KafkaCluster, KafkaListenerSource, Admi
     }
 
     private ZKClientConfig zkClientConfigFromKafkaConfig(Class<Server> kafkaServerClazz, KafkaConfig config) {
-        try {
-            var zkClientConfigFromKafkaConfigMethod = kafkaServerClazz.getDeclaredMethod("zkClientConfigFromKafkaConfig", KafkaConfig.class, Boolean.TYPE);
-            return (ZKClientConfig) zkClientConfigFromKafkaConfigMethod.invoke(null, config, false);
-        }
-        catch (Exception e) {
-            throw new IllegalStateException("Failed to invoke zkClientConfigFromKafkaConfig", e);
-        }
+        return ReflectionUtils.invokeStaticMethod(kafkaServerClazz, "zkClientConfigFromKafkaConfig", config, false);
     }
 
     // The accessibility hack is tactical for Kafka >=3.7.1 <= 4.0.0

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
@@ -35,7 +35,6 @@ import org.apache.kafka.common.utils.Time;
 import org.apache.zookeeper.client.ZKClientConfig;
 import org.apache.zookeeper.server.ServerCnxnFactory;
 import org.apache.zookeeper.server.ZooKeeperServer;
-import org.jetbrains.annotations.NotNull;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import kafka.server.KafkaConfig;
@@ -547,7 +546,7 @@ public class InVMKafkaCluster implements KafkaCluster, KafkaListenerSource, Admi
         }
     }
 
-    @NotNull
+    @NonNull
     private Class<?> getKafkaZkClientClazz() {
         try {
             return Class.forName("kafka.zk.KafkaZkClient");
@@ -557,7 +556,7 @@ public class InVMKafkaCluster implements KafkaCluster, KafkaListenerSource, Admi
         }
     }
 
-    @NotNull
+    @NonNull
     private Class<?> getKafkaAdminZkClientClazz() {
         try {
             return Class.forName("kafka.zk.AdminZkClient");

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/KraftLogDirUtil.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/KraftLogDirUtil.java
@@ -37,14 +37,24 @@ final class KraftLogDirUtil {
     }
 
     static void prepareLogDirsForKraft(String clusterId, KafkaConfig config, List<String> scramArguments) {
-        var metadataVersion = Optional.ofNullable(config.interBrokerProtocolVersionString()).map(MetadataVersion::fromVersionString)
-                .orElse(MetadataVersion.LATEST_PRODUCTION);
+        var metadataVersion = getMetadataVersion(config);
         var directoriesScala = StorageTool.configToLogDirectories(config);
         try {
             prepareLogDirsForKraftKafka39Plus(clusterId, config, scramArguments, directoriesScala, metadataVersion);
         }
         catch (Exception e) {
             prepareLogDirsForKraftPreKafka39(clusterId, config, directoriesScala, metadataVersion, scramArguments);
+        }
+    }
+
+    private static MetadataVersion getMetadataVersion(KafkaConfig config) {
+        try {
+            var method = config.getClass().getMethod("interBrokerProtocolVersionString");
+            var version = (String) method.invoke(config);
+            return Optional.ofNullable(version).map(MetadataVersion::fromVersionString).orElse(MetadataVersion.LATEST_PRODUCTION);
+        }
+        catch (Exception e) {
+            return MetadataVersion.LATEST_PRODUCTION;
         }
     }
 

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/KraftLogDirUtil.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/KraftLogDirUtil.java
@@ -49,8 +49,7 @@ final class KraftLogDirUtil {
 
     private static MetadataVersion getMetadataVersion(KafkaConfig config) {
         try {
-            var method = config.getClass().getMethod("interBrokerProtocolVersionString");
-            var version = (String) method.invoke(config);
+            String version = ReflectionUtils.invokeInstanceMethod(config, "interBrokerProtocolVersionString");
             return Optional.ofNullable(version).map(MetadataVersion::fromVersionString).orElse(MetadataVersion.LATEST_PRODUCTION);
         }
         catch (Exception e) {

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/ReflectionUtils.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/ReflectionUtils.java
@@ -57,9 +57,7 @@ class ReflectionUtils {
 
     private static void rejectNullParameters(Object[] parameters) {
         IntStream.range(0, parameters.length)
-                .forEach(i -> {
-                    Objects.requireNonNull(parameters[i], "Null parameters are not supported (parameter %d was null).".formatted(i + 1));
-                });
+                .forEach(i -> Objects.requireNonNull(parameters[i], "Null parameters are not supported (parameter %d was null).".formatted(i + 1)));
     }
 
     public static <R> R invokeInstanceMethod(@NonNull Object target, @NonNull String methodName, Object... parameters) {

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/ReflectionUtils.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/ReflectionUtils.java
@@ -7,13 +7,16 @@ package io.kroxylicious.testing.kafka.invm;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 class ReflectionUtils {
 
@@ -37,24 +40,57 @@ class ReflectionUtils {
         Constructor<?>[] declaredConstructors = clazz.getDeclaredConstructors();
         return Arrays.stream(declaredConstructors)
                 .filter(constructor -> Modifier.isPublic(constructor.getModifiers()))
-                .filter(constructor -> {
-                    if (constructor.getParameterCount() != parameters.length) {
-                        return false;
-                    }
-                    boolean allMatch = true;
-                    Class<?>[] parameterTypes = constructor.getParameterTypes();
-                    for (int i = 0; i < parameters.length; i++) {
-                        allMatch = allMatch && (parameterTypes[i].isAssignableFrom(parameters[i].getClass())
-                                || (parameterTypes[i].isPrimitive() && primitiveToBox.get(parameterTypes[i]).isAssignableFrom(parameters[i].getClass())));
-                    }
-                    return allMatch;
-                }).findFirst().map(constructor -> {
+                .filter(constructor -> matchingMethod(constructor.getParameterTypes(), parameters))
+                .findFirst().map(constructor -> {
                     try {
                         return (K) constructor.newInstance(parameters);
                     }
                     catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
-                        throw new RuntimeException(e);
+                        throw new IllegalStateException(e);
                     }
                 });
+    }
+
+    public static <R> R invokeInstanceMethod(@NonNull Object target, @NonNull String methodName, Object... parameters) {
+        var methods = target.getClass().getMethods();
+        return invokeMethod(target.getClass(), target, methodName, parameters, methods,
+                method -> Modifier.isPublic(method.getModifiers()) && !Modifier.isStatic(method.getModifiers()));
+    }
+
+    public static <R> R invokeStaticMethod(@NonNull Class<?> clazz, @NonNull String methodName, Object... parameters) {
+        var methods = clazz.getDeclaredMethods();
+        return invokeMethod(clazz, null, methodName, parameters, methods,
+                method -> Modifier.isPublic(method.getModifiers()) && Modifier.isStatic(method.getModifiers()));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <R> R invokeMethod(@NonNull Class<?> clazz, @Nullable Object target, @NonNull String methodName, Object[] parameters, Method[] methods,
+                                      Predicate<Method> methodPredicate) {
+        Optional<Method> first = Arrays.stream(methods)
+                .filter(method -> methodName.equals(method.getName()))
+                .filter(methodPredicate)
+                .filter(method -> matchingMethod(method.getParameterTypes(), parameters))
+                .findFirst();
+
+        var method = first.orElseThrow(() -> new UnsupportedOperationException("Can't find method %s on class %s".formatted(methodName, clazz.getName())));
+        try {
+            return (R) method.invoke(target, parameters);
+        }
+        catch (IllegalAccessException | InvocationTargetException e) {
+            throw new IllegalStateException("Failed to invoke method %s on object %s".formatted(methodName, clazz), e);
+        }
+    }
+
+    private static boolean matchingMethod(Class<?>[] methodParameterTypes, Object... parameters) {
+        if (methodParameterTypes.length != parameters.length) {
+            return false;
+        }
+        boolean allMatch = true;
+        for (int i = 0; i < parameters.length; i++) {
+            // What about nulls?
+            allMatch = allMatch && (methodParameterTypes[i].isAssignableFrom(parameters[i].getClass())
+                    || (methodParameterTypes[i].isPrimitive() && primitiveToBox.get(methodParameterTypes[i]).isAssignableFrom(parameters[i].getClass())));
+        }
+        return allMatch;
     }
 }

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/ReflectionUtils.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/ReflectionUtils.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.testing.kafka.invm;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+class ReflectionUtils {
+
+    private ReflectionUtils() {
+    }
+
+    private static final Map<Type, Class<?>> primitiveToBox = Map.of(
+            Boolean.TYPE, Boolean.class,
+            Byte.TYPE, Byte.class,
+            Character.TYPE, Character.class,
+            Short.TYPE, Short.class,
+            Integer.TYPE, Integer.class,
+            Long.TYPE, Long.class,
+            Double.TYPE, Double.class,
+            Float.TYPE, Float.class,
+            Void.TYPE, Void.TYPE);
+
+    @NonNull
+    @SuppressWarnings("unchecked")
+    public static <K> Optional<K> construct(Class<K> clazz, Object... parameters) {
+        Constructor<?>[] declaredConstructors = clazz.getDeclaredConstructors();
+        return Arrays.stream(declaredConstructors)
+                .filter(constructor -> Modifier.isPublic(constructor.getModifiers()))
+                .filter(constructor -> {
+                    if (constructor.getParameterCount() != parameters.length) {
+                        return false;
+                    }
+                    boolean allMatch = true;
+                    Class<?>[] parameterTypes = constructor.getParameterTypes();
+                    for (int i = 0; i < parameters.length; i++) {
+                        allMatch = allMatch && (parameterTypes[i].isAssignableFrom(parameters[i].getClass())
+                                || (parameterTypes[i].isPrimitive() && primitiveToBox.get(parameterTypes[i]).isAssignableFrom(parameters[i].getClass())));
+                    }
+                    return allMatch;
+                }).findFirst().map(constructor -> {
+                    try {
+                        return (K) constructor.newInstance(parameters);
+                    }
+                    catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+    }
+}

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/ReflectionUtils.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/ReflectionUtils.java
@@ -97,7 +97,6 @@ class ReflectionUtils {
         }
         boolean allMatch = true;
         for (int i = 0; i < parameters.length; i++) {
-            // What about nulls?
             allMatch = allMatch && (methodParameterTypes[i].isAssignableFrom(parameters[i].getClass())
                     || (methodParameterTypes[i].isPrimitive() && primitiveToBox.get(methodParameterTypes[i]).isAssignableFrom(parameters[i].getClass())));
         }

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/ReflectionUtils.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/ReflectionUtils.java
@@ -44,7 +44,8 @@ class ReflectionUtils {
         return Arrays.stream(declaredConstructors)
                 .filter(constructor -> Modifier.isPublic(constructor.getModifiers()))
                 .filter(constructor -> matchingMethod(constructor.getParameterTypes(), parameters))
-                .findFirst().map(constructor -> {
+                .findFirst()
+                .map(constructor -> {
                     try {
                         return (K) constructor.newInstance(parameters);
                     }

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/ScramUtils.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/ScramUtils.java
@@ -22,7 +22,6 @@ import org.apache.kafka.common.security.scram.ScramCredential;
 import org.apache.kafka.common.security.scram.internals.ScramFormatter;
 import org.apache.kafka.common.security.scram.internals.ScramMechanism;
 import org.apache.kafka.server.common.ApiMessageAndVersion;
-import org.jetbrains.annotations.NotNull;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -48,7 +47,7 @@ final class ScramUtils {
         }
     }
 
-    @NotNull
+    @NonNull
     static List<String> toKafkaScramArguments(String saslMechanism, Map<String, String> users) {
         var scramMechanism = ScramMechanism.forMechanismName(saslMechanism);
         if (scramMechanism == null) {

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaCluster.java
@@ -44,7 +44,6 @@ import java.util.stream.Stream;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.common.config.SslConfigs;
 import org.awaitility.Awaitility;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.TestInfo;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
@@ -345,15 +344,15 @@ public class TestcontainersKafkaCluster implements Startable, KafkaCluster, Kafk
         return repositoryRef.withTag(tag);
     }
 
-    private static @NotNull DockerImageName kafkaRegistryResolver() {
+    private static @NonNull DockerImageName kafkaRegistryResolver() {
         return DockerImageName.parse(Optional.ofNullable(System.getenv().get(KAFKA_IMAGE_REPO)).orElse(QUAY_KAFKA_IMAGE_REPO));
     }
 
-    private static @NotNull Supplier<String> kafkaTagResolver(KafkaClusterConfig clusterConfig) {
+    private static @NonNull Supplier<String> kafkaTagResolver(KafkaClusterConfig clusterConfig) {
         return () -> Optional.ofNullable(System.getenv().get(KAFKA_IMAGE_TAG)).orElse(defaultKafkaVersion(clusterConfig));
     }
 
-    private static @NotNull String defaultKafkaVersion(KafkaClusterConfig clusterConfig) {
+    private static @NonNull String defaultKafkaVersion(KafkaClusterConfig clusterConfig) {
         String defaultVersion;
         if (MAJOR_MINOR_PATCH.matcher(clusterConfig.getKafkaVersion()).matches()) {
             defaultVersion = "latest-kafka-" + clusterConfig.getKafkaVersion();
@@ -364,7 +363,7 @@ public class TestcontainersKafkaCluster implements Startable, KafkaCluster, Kafk
         return defaultVersion;
     }
 
-    private static @NotNull DockerImageName zookeeperRegistryResolver() {
+    private static @NonNull DockerImageName zookeeperRegistryResolver() {
         return DockerImageName.parse(Optional.ofNullable(System.getenv().get(ZOOKEEPER_IMAGE_REPO)).orElse(QUAY_ZOOKEEPER_IMAGE_REPO));
     }
 

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/invm/ReflectionUtilsTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/invm/ReflectionUtilsTest.java
@@ -14,7 +14,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class ReflectionUtilsTest {
 
     @Test
-    void constructNoArgs() {
+    void constructWithNoParameters() {
         var instance = ReflectionUtils.construct(NoArgs.class);
         assertThat(instance)
                 .isPresent()
@@ -23,7 +23,7 @@ class ReflectionUtilsTest {
     }
 
     @Test
-    void constructWithObjectArgs() {
+    void constructWithOneParameter() {
         var instance = ReflectionUtils.construct(ObjectArg.class, "foo");
         assertThat(instance)
                 .isPresent()
@@ -34,7 +34,7 @@ class ReflectionUtilsTest {
     }
 
     @Test
-    void constructWithPrimitiveArgs() {
+    void constructWithPrimitiveParameter() {
         var instance = ReflectionUtils.construct(PrimitiveArg.class, true);
         assertThat(instance)
                 .isPresent()
@@ -51,7 +51,14 @@ class ReflectionUtilsTest {
     }
 
     @Test
-    void invokeInstanceMethodWithNoArgs() {
+    void constructWithParameterWithNullValueRejected() {
+        assertThatThrownBy(() -> ReflectionUtils.construct(ObjectArg.class, "foo", null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("Null parameters are not supported (parameter 2 was null).");
+    }
+
+    @Test
+    void invokeInstanceMethodWithNoParameters() {
         var obj = new ObjectArg("foo");
 
         var result = ReflectionUtils.invokeInstanceMethod(obj, "getArg");
@@ -59,7 +66,7 @@ class ReflectionUtilsTest {
     }
 
     @Test
-    void invokeInstanceMethodWithArgsReturningNonVoid() {
+    void invokeInstanceMethodWithParameterReturningNonVoid() {
         var obj = new MyObject();
 
         var result = ReflectionUtils.invokeInstanceMethod(obj, "reverseMe", "oof");
@@ -67,7 +74,7 @@ class ReflectionUtilsTest {
     }
 
     @Test
-    void invokeInstanceMethodWithArgsReturningVoid() {
+    void invokeInstanceMethodWithParameterReturningVoid() {
         var obj = new MyObject();
 
         var result = ReflectionUtils.invokeInstanceMethod(obj, "myMethodReturningVoid", "oof");
@@ -75,13 +82,13 @@ class ReflectionUtilsTest {
     }
 
     @Test
-    void invokeStaticMethodWithArgsReturningNonVoid() {
+    void invokeStaticMethodWithParameterReturningNonVoid() {
         var result = ReflectionUtils.invokeStaticMethod(MyObject.class, "staticReverseMe", "oof");
         assertThat(result).isEqualTo("foo");
     }
 
     @Test
-    void invokeInstanceMethodNotFound() {
+    void instanceMethodNotFound() {
         var obj = new MyObject();
 
         assertThatThrownBy(() -> ReflectionUtils.invokeInstanceMethod(obj, "notFound"))
@@ -90,7 +97,7 @@ class ReflectionUtilsTest {
     }
 
     @Test
-    void invokeStaticMethodNotFound() {
+    void staticMethodNotFound() {
         assertThatThrownBy(() -> ReflectionUtils.invokeStaticMethod(MyObject.class, "notFound"))
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessageContaining("Can't find method notFound on class io.kroxylicious.testing.kafka.invm.ReflectionUtilsTest$MyObject");
@@ -101,6 +108,15 @@ class ReflectionUtilsTest {
         assertThatThrownBy(() -> ReflectionUtils.invokeStaticMethod(MyObject.class, "reverseMe"))
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessageContaining("Can't find method reverseMe on class io.kroxylicious.testing.kafka.invm.ReflectionUtilsTest$MyObject");
+    }
+
+    @Test
+    void invokeWithParameterWithNullValueRejected() {
+        var obj = new MyObject();
+
+        assertThatThrownBy(() -> ReflectionUtils.invokeInstanceMethod(obj, "myMethodReturningVoid", null, "foo"))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("Null parameters are not supported (parameter 1 was null).");
     }
 
     // These classes are used reflectively by the tests.

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/invm/ReflectionUtilsTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/invm/ReflectionUtilsTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.testing.kafka.invm;
+
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ReflectionUtilsTest {
+
+    @Test
+    void constructNoArgs() {
+        var instance = ReflectionUtils.construct(NoArgs.class);
+        assertThat(instance)
+                .isPresent()
+                .get()
+                .isInstanceOf(NoArgs.class);
+    }
+
+    @Test
+    void constructWithObjectArgs() {
+        var instance = ReflectionUtils.construct(ObjectArg.class, "foo");
+        assertThat(instance)
+                .isPresent()
+                .get()
+                .asInstanceOf(InstanceOfAssertFactories.type(ObjectArg.class))
+                .extracting(ObjectArg::getArg)
+                .isEqualTo("foo");
+    }
+
+    @Test
+    void constructWithPrimitiveArgs() {
+        var instance = ReflectionUtils.construct(PrimitiveArg.class, true);
+        assertThat(instance)
+                .isPresent()
+                .get()
+                .asInstanceOf(InstanceOfAssertFactories.type(PrimitiveArg.class))
+                .extracting(PrimitiveArg::getArg)
+                .isEqualTo(true);
+    }
+
+    @Test
+    void noMatchingConstructor() {
+        var instance = ReflectionUtils.construct(ObjectArg.class, 12);
+        assertThat(instance).isEmpty();
+    }
+
+    @Test
+    void invokeInstanceMethodWithNoArgs() {
+        var obj = new ObjectArg("foo");
+
+        var result = ReflectionUtils.invokeInstanceMethod(obj, "getArg");
+        assertThat(result).isEqualTo("foo");
+    }
+
+    @Test
+    void invokeInstanceMethodWithArgsReturningNonVoid() {
+        var obj = new MyObject();
+
+        var result = ReflectionUtils.invokeInstanceMethod(obj, "reverseMe", "oof");
+        assertThat(result).isEqualTo("foo");
+    }
+
+    @Test
+    void invokeInstanceMethodWithArgsReturningVoid() {
+        var obj = new MyObject();
+
+        var result = ReflectionUtils.invokeInstanceMethod(obj, "myMethodReturningVoid", "oof");
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void invokeStaticMethodWithArgsReturningNonVoid() {
+        var result = ReflectionUtils.invokeStaticMethod(MyObject.class, "staticReverseMe", "oof");
+        assertThat(result).isEqualTo("foo");
+    }
+
+    @Test
+    void invokeInstanceMethodNotFound() {
+        var obj = new MyObject();
+
+        assertThatThrownBy(() -> ReflectionUtils.invokeInstanceMethod(obj, "notFound"))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("Can't find method notFound on class io.kroxylicious.testing.kafka.invm.ReflectionUtilsTest$MyObject");
+    }
+
+    @Test
+    void invokeStaticMethodNotFound() {
+        assertThatThrownBy(() -> ReflectionUtils.invokeStaticMethod(MyObject.class, "notFound"))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("Can't find method notFound on class io.kroxylicious.testing.kafka.invm.ReflectionUtilsTest$MyObject");
+    }
+
+    @Test
+    void detectsInstanceMethodInvokedStatic() {
+        assertThatThrownBy(() -> ReflectionUtils.invokeStaticMethod(MyObject.class, "reverseMe"))
+                .isInstanceOf(UnsupportedOperationException.class)
+                .hasMessageContaining("Can't find method reverseMe on class io.kroxylicious.testing.kafka.invm.ReflectionUtilsTest$MyObject");
+    }
+
+    // These classes are used reflectively by the tests.
+    static class NoArgs {
+        public NoArgs() {
+            super();
+        }
+    }
+
+    static class ObjectArg {
+        private final String arg;
+
+        public ObjectArg(String arg) {
+            super();
+            this.arg = arg;
+        }
+
+        public String getArg() {
+            return arg;
+        }
+    }
+
+    static class PrimitiveArg {
+        private final boolean arg;
+
+        public PrimitiveArg(boolean arg) {
+            super();
+            this.arg = arg;
+        }
+
+        public boolean getArg() {
+            return arg;
+        }
+    }
+
+    static class MyObject {
+
+        public String reverseMe(String arg) {
+            return new StringBuilder(arg).reverse().toString();
+        }
+
+        public void myMethodReturningVoid(String arg) {
+        }
+
+        public static String staticReverseMe(String arg) {
+            return new StringBuilder(arg).reverse().toString();
+        }
+    }
+}

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/AbstractExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/AbstractExtensionTest.java
@@ -23,6 +23,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
 
 public abstract class AbstractExtensionTest {
+    public static boolean zookeeperAvailable() {
+        try {
+            Class.forName("kafka.server.KafkaServer");
+            return true;
+        }
+        catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
     protected DescribeClusterResult describeCluster(Map<String, Object> adminConfig) throws InterruptedException, ExecutionException {
         try (var admin = Admin.create(adminConfig)) {
             return describeCluster(admin);

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/ParameterExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/ParameterExtensionTest.java
@@ -29,6 +29,7 @@ import org.apache.kafka.common.errors.SaslAuthenticationException;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -180,6 +181,7 @@ class ParameterExtensionTest extends AbstractExtensionTest {
     }
 
     @Test
+    @EnabledIf("io.kroxylicious.testing.kafka.junit5ext.AbstractExtensionTest#zookeeperAvailable")
     void zkBasedClusterParameter(@BrokerCluster @ZooKeeperCluster KafkaCluster cluster)
             throws Exception {
         assertClusterSize(cluster, 1);

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/TemplateTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/TemplateTest.java
@@ -173,7 +173,8 @@ class TemplateTest {
             if (ZOOKEEPER_AVAILABLE) {
                 expected.add(List.of(3, -1));
             }
-            assertThat(observedTuples).isEqualTo(expected);
+            assertThat(observedTuples)
+                    .containsExactlyInAnyOrderElementsOf(expected);
         }
     }
 
@@ -204,7 +205,9 @@ class TemplateTest {
 
         @AfterAll
         void afterAll() {
-            assertThat(observedVersions).isEqualTo(versions().map(Version::value).collect(Collectors.toSet()));
+            var expected = versions().map(Version::value).collect(Collectors.toSet());
+            assertThat(observedVersions)
+                    .containsExactlyInAnyOrderElementsOf(expected);
         }
     }
 


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Refactoring

### Description

As a first step towards Kafka 4.0 support (and the retention of ability to form Kafka clusters with Zookeeper controllers when using older Kafka versions), refactor the code so that Zookeeper based Kafka is instantiated exclusively using reflection.

Also refactors the test suite so that test that need Zookeeper skip if Zookeeper is not present on the classpath.

This change does not **require** Kafka 4.0.0.  My intent is that this is committed first, then a follow up change will make the Kafka 4.0 specific changes.

Step towards #389 

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [x] Write tests
- [x] Make sure all tests pass
- [x] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
