### PR TITLE
Simple CI test matrix running the extension against the older Kafka versions

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -46,6 +46,13 @@ jobs:
           distribution: 'zulu'
           cache: maven
 
+      - name: 'Cache Maven packages'
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
       - name: Cache SonarCloud packages
         uses: actions/cache@v4
         with:
@@ -81,6 +88,58 @@ jobs:
         with:
           name: PR_NUMBER
           path: PR_NUMBER.txt
+
+      - name: Archive container logs
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: container-logs
+          path: "**/container-logs/**/*.log"
+
+  older_kafka_matrix:
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      matrix:
+        version: [3.8.0]
+    steps:
+      - name: 'Check out repository'
+        uses: actions/checkout@v4
+        with:
+          submodules: 'true'
+          fetch-depth: 0
+
+      - name: 'Set up Java'
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: 'zulu'
+          cache: maven
+
+      - name: 'Cache Maven packages'
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: 'Install junit extension'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: mvn -B install -DskipTests=true
+
+      - name: 'Run select junit tests (Kafka in-VM)'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # Note - the extension won't necessarily compile against the earlier versions of Kafka.
+        # We want to run the tests against the code that was compiled in the install step, just with
+        # a different version of Kafka on the classpath.
+        run: mvn -Dmaven.main.skip=true -Dmaven.javadoc.skip=true -pl impl,junit5-extension -B test -Dtest=KafkaClusterTest,ParameterExtensionTest -Dkafka.version=${{ matrix.version }}
+
+      - name: 'Run select junit tests (Kafka containers)'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: TEST_CLUSTER_EXECUTION_MODE=CONTAINER KAFKA_VERSION=${{ matrix.version }} mvn -Dmaven.main.skip=true -Dmaven.javadoc.skip=true -pl impl,junit5-extension -B test -Dtest=KafkaClusterTest,ParameterExtensionTest -Dkafka.version=${{ matrix.version }}
 
       - name: Archive container logs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -139,7 +139,8 @@ jobs:
       - name: 'Run select junit tests (Kafka containers)'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: TEST_CLUSTER_EXECUTION_MODE=CONTAINER KAFKA_VERSION=${{ matrix.version }} mvn -Dmaven.main.skip=true -Dmaven.javadoc.skip=true -pl impl,junit5-extension -B test -Dtest=KafkaClusterTest,ParameterExtensionTest -Dkafka.version=${{ matrix.version }}
+        # The annotations don't respect env var TEST_CLUSTER_EXECUTION_MODE, so running ParameterExtensionTest is pointless.
+        run: TEST_CLUSTER_EXECUTION_MODE=CONTAINER KAFKA_VERSION=${{ matrix.version }} mvn -Dmaven.main.skip=true -Dmaven.javadoc.skip=true -pl impl -B test -Dtest=KafkaClusterTest -Dkafka.version=${{ matrix.version }}
 
       - name: Archive container logs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -140,7 +140,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # The annotations don't respect env var TEST_CLUSTER_EXECUTION_MODE, so running ParameterExtensionTest is pointless.
-        run: TEST_CLUSTER_EXECUTION_MODE=CONTAINER KAFKA_VERSION=${{ matrix.version }} mvn -Dmaven.main.skip=true -Dmaven.javadoc.skip=true -pl impl -B test -Dtest=KafkaClusterTest -Dkafka.version=${{ matrix.version }}
+        run: TEST_CLUSTER_EXECUTION_MODE=CONTAINER mvn -Dmaven.main.skip=true -Dmaven.javadoc.skip=true -pl impl -B test -Dtest=KafkaClusterTest -Dkafka.version=${{ matrix.version }}
 
       - name: Archive container logs
         uses: actions/upload-artifact@v4

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/common/KafkaClusterConfig.java
@@ -332,7 +332,9 @@ public class KafkaClusterConfig {
         putConfig(nodeConfiguration, "listener.security.protocol.map", formatListeners(protocolMap, ":"));
         putConfig(nodeConfiguration, "listeners", formatListeners(listeners, "://"));
         putConfig(nodeConfiguration, "early.start.listeners", String.join(",", earlyStart));
-        putConfig(nodeConfiguration, "advertised.listeners", formatListeners(advertisedListeners, "://"));
+        if (!advertisedListeners.isEmpty()) {
+            putConfig(nodeConfiguration, "advertised.listeners", formatListeners(advertisedListeners, "://"));
+        }
 
         configureSasl(nodeConfiguration);
 

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/KafkaClusterTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/KafkaClusterTest.java
@@ -31,6 +31,7 @@ import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.errors.SaslAuthenticationException;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.server.common.MetadataVersion;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.awaitility.Awaitility;
@@ -44,6 +45,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import kafka.Kafka;
 import kafka.server.KafkaConfig;
 
 import io.kroxylicious.testing.kafka.api.KafkaCluster;
@@ -67,6 +69,12 @@ import static org.junit.jupiter.api.Assertions.fail;
  */
 @Timeout(value = 2, unit = TimeUnit.MINUTES)
 class KafkaClusterTest {
+
+    private static final System.Logger LOGGER = System.getLogger(KafkaClusterTest.class.getName());
+
+    static {
+        LOGGER.log(System.Logger.Level.INFO, "Kafka on classpath is version: {0}", AppInfoParser.getVersion());
+    }
 
     private static final boolean ZOOKEEPER_AVAILABLE = zookeeperAvailable();
     private TestInfo testInfo;


### PR DESCRIPTION

### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

Simple CI test matrix running the extension against the older Kafka versions

Why: #455 we want the extension to keep working against older Kafka versions.  We therefore need adequate test support.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
