### PR TITLE
Skip sonar step in CI workflow if SONAR_TOKEN is not available

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -27,6 +27,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: 'Test for Sonar secret'
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          echo "SONAR_TOKEN_SET=$(test ${SONAR_TOKEN} && echo true)" >> $GITHUB_ENV
+
       - name: 'Check out repository'
         uses: actions/checkout@v4
         with:
@@ -48,13 +54,13 @@ jobs:
           restore-keys: ${{ runner.os }}-sonar
 
       - name: 'Build junit extension with maven tests'
-        if: github.ref_name != 'main'
+        if: github.ref_name != 'main' || env.SONAR_TOKEN_SET != 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: mvn -B clean verify -Pci
 
       - name: 'Build junit extension  maven project on main'
-        if: github.event_name == 'push' && github.ref_name == 'main'
+        if: github.event_name == 'push' && github.ref_name == 'main' && env.SONAR_TOKEN_SET == 'true'
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION

### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

Skip sonar step in CI workflow if SONAR_TOKEN is not available

why: play nice with people running CI workflows on their fork who might not have a SONAR_TOKEN secret set in their GitHub account.

_Please describe your pull request_

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
