### PR TITLE
feat: junit extension prefers TEST_CLUSTER_EXECUTION_MODE env var when selecting a provisioning mechanism

### DIFF
--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -50,7 +50,7 @@ The kafka environment used by the integrations tests can be _defaulted_ with the
 
 | env var                       | default | description                                                                                                                             |
 |-------------------------------|---------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| `TEST_CLUSTER_EXECUTION_MODE` | `IN_VM` | `IN_VM` or `CONTAINER`. if `IN_VM`, kafka will be run same virtual machines as the integration test. Otherwise containers will be used. |
+| `TEST_CLUSTER_EXECUTION_MODE` | `IN_VM` | `IN_VM` or `CONTAINER`. if `IN_VM`, kafka will prefer to run in the same virtual machines as the integration test. Otherwise containers will be used. |
 | `TEST_CLUSTER_KRAFT_MODE`     | `true`  | if true, kafka will be run in kraft mode.                                                                                               |
 
 When the integration-tests are run in `CONTAINER` mode, the kafka/zookeeper logs are written to a location specified by

--- a/README.md
+++ b/README.md
@@ -1,5 +1,26 @@
 # Kafka Cluster JUnit 5 extension
 
+<!-- TOC -->
+* [Kafka Cluster JUnit 5 extension](#kafka-cluster-junit-5-extension)
+  * [What?](#what)
+  * [Dependency](#dependency)
+  * [Example](#example)
+  * [Adding Constraints](#adding-constraints)
+  * [Configuring Kafka Brokers](#configuring-kafka-brokers)
+  * [Configuring SASL](#configuring-sasl)
+  * [Configuring Kafka Clients](#configuring-kafka-clients)
+  * [Creating Test Topics](#creating-test-topics)
+  * [Node topology](#node-topology)
+  * [Provisioning mechanisms](#provisioning-mechanisms)
+    * [Choosing the Provisioning mechanism](#choosing-the-provisioning-mechanism)
+  * [Field injection and Parameter Resolution](#field-injection-and-parameter-resolution)
+  * [Template tests](#template-tests)
+  * [Custom cluster provisioning and constraints](#custom-cluster-provisioning-and-constraints)
+  * [Developer Guide](#developer-guide)
+  * [Releasing this project](#releasing-this-project)
+  * [Contributing](#contributing)
+<!-- TOC -->
+
 ## What?
 
 This is a JUnit 5 extension that allows writing tests that require a Kafka cluster
@@ -190,6 +211,21 @@ In case you use podman for testcontainers, some tips must be taken into account:
 
 ---
 
+### Choosing the Provisioning mechanism
+
+By default, `KafkaCluster` prefers to run in the same JVM as your tests. You can override this globally or for specific 
+tests.
+
+* **Global Container Mode**: To prefer running the cluster in a container, set this environment variable:
+    ```bash
+    export TEST_CLUSTER_EXECUTION_MODE=CONTAINER
+    ```
+
+* **Per-Test Override**: For a specific test, directly inject the cluster implementation you need:
+    * `InVMKafkaCluster` (in-JVM)
+    * `TestcontainersKafkaCluster` (container)
+
+
 ## Field injection and Parameter Resolution
 
 The extension supports injecting clusters and clients:
@@ -345,3 +381,7 @@ See the [developer guide](DEV_GUIDE.md).
 ## Releasing this project
 
 See the [releasing guide](RELEASING.md).
+
+## Contributing
+
+We welcome contributions! Please see our [contributing guidelines](https://github.com/kroxylicious/.github/blob/main/CONTRIBUTING.md) to get started.

--- a/junit5-extension/pom.xml
+++ b/junit5-extension/pom.xml
@@ -44,6 +44,11 @@
             <artifactId>junit-jupiter-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.junit-pioneer</groupId>
+            <artifactId>junit-pioneer</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/ParameterExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/ParameterExtensionTest.java
@@ -31,6 +31,7 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junitpioneer.jupiter.SetEnvironmentVariable;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -39,11 +40,13 @@ import io.kroxylicious.testing.kafka.common.BrokerCluster;
 import io.kroxylicious.testing.kafka.common.BrokerConfig;
 import io.kroxylicious.testing.kafka.common.ClientConfig;
 import io.kroxylicious.testing.kafka.common.KRaftCluster;
+import io.kroxylicious.testing.kafka.common.KafkaClusterFactory;
 import io.kroxylicious.testing.kafka.common.SaslMechanism;
 import io.kroxylicious.testing.kafka.common.SaslMechanism.Principal;
 import io.kroxylicious.testing.kafka.common.Tls;
 import io.kroxylicious.testing.kafka.common.ZooKeeperCluster;
 import io.kroxylicious.testing.kafka.invm.InVMKafkaCluster;
+import io.kroxylicious.testing.kafka.testcontainers.TestcontainersKafkaCluster;
 
 import static org.apache.kafka.common.config.TopicConfig.CLEANUP_POLICY_COMPACT;
 import static org.apache.kafka.common.config.TopicConfig.CLEANUP_POLICY_CONFIG;
@@ -63,6 +66,20 @@ class ParameterExtensionTest extends AbstractExtensionTest {
 
     @Test
     void clusterParameter(@BrokerCluster(numBrokers = 2) KafkaCluster cluster) throws Exception {
+        assertThat(cluster).isInstanceOf(InVMKafkaCluster.class);
+        assertClusterIdAndSize(cluster, 2);
+    }
+
+    @SetEnvironmentVariable(key = KafkaClusterFactory.TEST_CLUSTER_EXECUTION_MODE, value = "CONTAINER")
+    @Test
+    void clusterParameterPreferenceContainer(@BrokerCluster(numBrokers = 2) KafkaCluster cluster) throws Exception {
+        assertThat(cluster).isInstanceOf(TestcontainersKafkaCluster.class);
+        assertClusterIdAndSize(cluster, 2);
+    }
+
+    @SetEnvironmentVariable(key = KafkaClusterFactory.TEST_CLUSTER_EXECUTION_MODE, value = "IN_VM")
+    @Test
+    void clusterParameterPreferenceInVm(@BrokerCluster(numBrokers = 2) KafkaCluster cluster) throws Exception {
         assertThat(cluster).isInstanceOf(InVMKafkaCluster.class);
         assertClusterIdAndSize(cluster, 2);
     }


### PR DESCRIPTION

### Type of change

- Enhancement / new feature

### Description

This change introduces a way to control the selection of a cluster provider using an environment variable.

When multiple providers can satisfy the constraints for a cluster injection, you can now set the `TEST_CLUSTER_PREFERRED_EXECUTION_MODE` environment variable to prefer one of the modes. If the variable is not set, the existing logic of preferring the fastest provider remains unchanged.

This is necessary because the current behavior defaults to the fastest provider, making it impossible to force an entire test suite to prefer Testcontainers. I would like to be able to run the kroxylicious/kroxylicious tests, preferring to use testcontainers wherever possible, to exercise container mode.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
