### PR TITLE
Add topicId to injected Topic

### DIFF
--- a/junit5-extension/src/main/java/io/kroxylicious/testing/kafka/junit5ext/Topic.java
+++ b/junit5-extension/src/main/java/io/kroxylicious/testing/kafka/junit5ext/Topic.java
@@ -5,6 +5,10 @@
  */
 package io.kroxylicious.testing.kafka.junit5ext;
 
+import java.util.Optional;
+
+import org.apache.kafka.common.Uuid;
+
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
@@ -15,4 +19,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 public interface Topic {
     @NonNull
     String name();
+
+    /**
+     * @return the topic id of the created topic, will be non-empty for kafka versions >=2.8
+     */
+    @NonNull
+    Optional<Uuid> topicId();
 }

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/InstanceFieldExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/InstanceFieldExtensionTest.java
@@ -12,6 +12,7 @@ import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.MockConsumer;
 import org.apache.kafka.clients.consumer.OffsetResetStrategy;
 import org.apache.kafka.clients.producer.Producer;
+import org.assertj.core.api.ObjectAssert;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,6 +24,7 @@ import io.kroxylicious.testing.kafka.common.BrokerCluster;
 import io.kroxylicious.testing.kafka.invm.InVMKafkaCluster;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.OPTIONAL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
@@ -78,9 +80,10 @@ class InstanceFieldExtensionTest extends AbstractExtensionTest {
 
     @Test
     void shouldInjectTopicField() {
-        assertThat(injectedTopic)
-                .isNotNull()
-                .extracting(Topic::name).isNotNull();
+        ObjectAssert<Topic> topicAssert = assertThat(injectedTopic)
+                .isNotNull();
+        topicAssert.extracting(Topic::name).isNotNull();
+        topicAssert.extracting(Topic::topicId, OPTIONAL).isNotNull().isNotEmpty();
     }
 
     @Test

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/StaticFieldExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/StaticFieldExtensionTest.java
@@ -14,6 +14,7 @@ import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
+import org.assertj.core.api.ObjectAssert;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,6 +24,7 @@ import io.kroxylicious.testing.kafka.common.BrokerCluster;
 import io.kroxylicious.testing.kafka.invm.InVMKafkaCluster;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.OPTIONAL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
@@ -62,9 +64,10 @@ class StaticFieldExtensionTest extends AbstractExtensionTest {
 
     @Test
     void topicStaticField() throws ExecutionException, InterruptedException {
-        assertThat(staticTopic)
-                .isNotNull()
-                .extracting(Topic::name).isNotNull();
+        ObjectAssert<Topic> topicAssert = assertThat(staticTopic)
+                .isNotNull();
+        topicAssert.extracting(Topic::name).isNotNull();
+        topicAssert.extracting(Topic::topicId, OPTIONAL).isNotNull().isNotEmpty();
     }
 
     @Test


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Obtaining the topicId for a topic is a little bit of a hassle for users. You have to use the admin client, describe the topics and handle the Future work. We already know the topicId at creation time.

Closes #513 
### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
