### PR TITLE
Enable user to influence automatically named Topic naming strategy

### DIFF
--- a/junit5-extension/src/main/java/io/kroxylicious/testing/kafka/junit5ext/NamingStrategy.java
+++ b/junit5-extension/src/main/java/io/kroxylicious/testing/kafka/junit5ext/NamingStrategy.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.testing.kafka.junit5ext;
+
+public enum NamingStrategy {
+    /**
+     * name is composed of a random lowercase adjective, an underscore and random lowercase noun
+     */
+    RANDOM_ADJECTIVE_UNDERSCORE_NOUN,
+    /**
+     * name is composed of a random lowercase adjective, an underscore and random lowercase noun
+     */
+    RANDOM_ADJECTIVE_HYPHEN_NOUN
+}

--- a/junit5-extension/src/main/java/io/kroxylicious/testing/kafka/junit5ext/TopicNamingStrategy.java
+++ b/junit5-extension/src/main/java/io/kroxylicious/testing/kafka/junit5ext/TopicNamingStrategy.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.testing.kafka.junit5ext;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Used to specify the naming strategy for topics automatically created by the extension
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.FIELD, ElementType.PARAMETER })
+public @interface TopicNamingStrategy {
+    NamingStrategy value();
+}

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/AbstractExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/AbstractExtensionTest.java
@@ -23,6 +23,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
 
 public abstract class AbstractExtensionTest {
+
+    public static final String RANDOM_ADJECTIVE_UNDERSCORE_NOUN_PATTERN = "^[a-z]+_[a-z]+$";
+    public static final String RANDOM_ADJECTIVE_HYPHEN_NOUN_PATTERN = "^[a-z]+-[a-z]+$";
+
     public static boolean zookeeperAvailable() {
         try {
             Class.forName("kafka.server.KafkaServer");

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/InstanceFieldExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/InstanceFieldExtensionTest.java
@@ -25,6 +25,7 @@ import io.kroxylicious.testing.kafka.invm.InVMKafkaCluster;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.OPTIONAL;
+import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
@@ -43,6 +44,9 @@ class InstanceFieldExtensionTest extends AbstractExtensionTest {
     Admin injectedAdmin;
 
     Topic injectedTopic;
+
+    @TopicNamingStrategy(NamingStrategy.RANDOM_ADJECTIVE_HYPHEN_NOUN)
+    Topic injectedTopic2;
 
     private Admin privateField;
 
@@ -82,7 +86,15 @@ class InstanceFieldExtensionTest extends AbstractExtensionTest {
     void shouldInjectTopicField() {
         ObjectAssert<Topic> topicAssert = assertThat(injectedTopic)
                 .isNotNull();
-        topicAssert.extracting(Topic::name).isNotNull();
+        topicAssert.extracting(Topic::name, STRING).isNotNull().matches(RANDOM_ADJECTIVE_UNDERSCORE_NOUN_PATTERN);
+        topicAssert.extracting(Topic::topicId, OPTIONAL).isNotNull().isNotEmpty();
+    }
+
+    @Test
+    void shouldInjectTopicFieldWithNamingStrategy() {
+        ObjectAssert<Topic> topicAssert = assertThat(injectedTopic2)
+                .isNotNull();
+        topicAssert.extracting(Topic::name, STRING).isNotNull().matches(RANDOM_ADJECTIVE_HYPHEN_NOUN_PATTERN);
         topicAssert.extracting(Topic::topicId, OPTIONAL).isNotNull().isNotEmpty();
     }
 

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/ParameterExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/ParameterExtensionTest.java
@@ -297,7 +297,7 @@ class ParameterExtensionTest extends AbstractExtensionTest {
             throws Exception {
 
         ObjectAssert<Topic> topicAssert = assertThat(topic).isNotNull();
-        topicAssert.extracting(Topic::name).isNotNull();
+        assertThat(topic).isNotNull().extracting(Topic::name, STRING).isNotNull().matches(RANDOM_ADJECTIVE_UNDERSCORE_NOUN_PATTERN);
         topicAssert.extracting(Topic::topicId, OPTIONAL).isNotNull().isNotEmpty();
 
         var result = admin.describeTopics(List.of(topic.name())).allTopicNames().get(5, TimeUnit.SECONDS);
@@ -322,6 +322,18 @@ class ParameterExtensionTest extends AbstractExtensionTest {
         var topicConfig = all.get(resourceKey);
         assertThat(topicConfig).isNotNull();
         assertConfigValue(topicConfig, CLEANUP_POLICY_CONFIG, CLEANUP_POLICY_COMPACT);
+    }
+
+    @Test
+    void topicNamingStrategyRandomAdjectiveHyphenNoun(KafkaCluster cluster,
+                                                      @TopicNamingStrategy(NamingStrategy.RANDOM_ADJECTIVE_HYPHEN_NOUN) Topic topic) {
+        assertThat(topic).isNotNull().extracting(Topic::name, STRING).isNotNull().matches(RANDOM_ADJECTIVE_HYPHEN_NOUN_PATTERN);
+    }
+
+    @Test
+    void topicNamingStrategyRandomAdjectiveUnderscoreNoun(KafkaCluster cluster,
+                                                          @TopicNamingStrategy(NamingStrategy.RANDOM_ADJECTIVE_UNDERSCORE_NOUN) Topic topic) {
+        assertThat(topic).isNotNull().extracting(Topic::name, STRING).isNotNull().matches(RANDOM_ADJECTIVE_UNDERSCORE_NOUN_PATTERN);
     }
 
     @Test

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/StaticFieldExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/StaticFieldExtensionTest.java
@@ -25,6 +25,7 @@ import io.kroxylicious.testing.kafka.invm.InVMKafkaCluster;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.OPTIONAL;
+import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
@@ -42,6 +43,9 @@ class StaticFieldExtensionTest extends AbstractExtensionTest {
     static AdminClient staticAdminClient;
 
     static Topic staticTopic;
+
+    @TopicNamingStrategy(NamingStrategy.RANDOM_ADJECTIVE_HYPHEN_NOUN)
+    static Topic staticTopicWithNaming;
 
     @Test
     void testKafkaClusterStaticField()
@@ -63,10 +67,18 @@ class StaticFieldExtensionTest extends AbstractExtensionTest {
     }
 
     @Test
-    void topicStaticField() throws ExecutionException, InterruptedException {
+    void topicStaticField() {
         ObjectAssert<Topic> topicAssert = assertThat(staticTopic)
                 .isNotNull();
-        topicAssert.extracting(Topic::name).isNotNull();
+        topicAssert.extracting(Topic::name, STRING).isNotNull().matches(RANDOM_ADJECTIVE_UNDERSCORE_NOUN_PATTERN);
+        topicAssert.extracting(Topic::topicId, OPTIONAL).isNotNull().isNotEmpty();
+    }
+
+    @Test
+    void topicStaticFieldWithNamingStrategy() {
+        ObjectAssert<Topic> topicAssert = assertThat(staticTopicWithNaming)
+                .isNotNull();
+        topicAssert.extracting(Topic::name, STRING).isNotNull().matches(RANDOM_ADJECTIVE_HYPHEN_NOUN_PATTERN);
         topicAssert.extracting(Topic::topicId, OPTIONAL).isNotNull().isNotEmpty();
     }
 


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

The extension can create and automatically name topics for users, with the theory that users often just want a topic to operate on. If the user has to be responsible for the naming it's often just irrelevant noise. So the framework handles it.

However, sometimes the topic naming may have other consequences. For example if some technology wants to use the topic names for some other purpose, it can be useful to constrain how we name it. For example the length and what characters are used. For instance, a user might want the topic name to also be a valid identifier in a third party system (the example I'm thinking of is that it is a valid Key name in a cloud provided KMS) so that some business logic can be applied.

The two strategies are:
* `RANDOM_ADJECTIVE_UNDERSCORE_NOUN` - eg `unruffled_hawking` (default)
* `RANDOM_ADJECTIVE_HYPHEN_NOUN` - eg `suspicious-newton`

For example to control the naming of a parameter injected Topic:
```java
@TopicNamingStrategy(NamingStrategy.RANDOM_ADJECTIVE_HYPHEN_NOUN) Topic topic
```

this is something that would improve the testing situation for the upcoming Azure Key Vault KMS in the proxy repository. The existing integration tests produce topic names that are not valid Key Vault key names, due to the underscore. By adding this we can make a relatively unobtrusive change of annotating the Topic creations.

I wondered a little if we could change the default behaviour but it's risky for our integration tests to depend on some unspecified naming convention, so I think this explicit style has it's place.

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
