### PR TITLE
Enable users to customize the names of topics created by the extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Please enumerate all user-facing changes using format `<githib issue/pr number>:
 
 ## SNAPSHOT
 
+* [#519](https://github.com/kroxylicious/kroxylicious-junit5-extension/pull/519): Enable Users to customize automatically created Topic names
 * [#474](https://github.com/kroxylicious/kroxylicious-junit5-extension/pull/#474): Remove deprecated @SaslPlainAuth annotation
 * [#501](https://github.com/kroxylicious/kroxylicious-junit5-extension/pull/501): Upgrade to Kafka 4.1.0
 
@@ -16,6 +17,11 @@ Please enumerate all user-facing changes using format `<githib issue/pr number>:
   the old images will be uses. If you target a kafka version greater-than-or-equal-to 4.1.0, then an 
   apache image will be used. Images will be pulled from `mirror.gcr.io/apache/kafka`, this value can
   be overridden by setting the `APACHE_KAFKA_IMAGE_REPO` environment variable.
+* Introduces the `@TopicNameMethodSource` annotation. If users need to control the naming of automatically
+  created topics, then they can annotate their Topic parameter or field with a reference to a static no-args
+  method that returns String. This method will be invoked by the extension to obtain the name for the topic.
+  This allows you to precisely control the characters used and length of the name, or add a prefix to the topic
+  names for a test.
 
 ## 0.11.0
 

--- a/junit5-extension/pom.xml
+++ b/junit5-extension/pom.xml
@@ -54,6 +54,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <!-- Note we use System.Logger facade in src/main/java. log4j2 only for the tests -->
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>

--- a/junit5-extension/src/main/java/io/kroxylicious/testing/kafka/junit5ext/Topic.java
+++ b/junit5-extension/src/main/java/io/kroxylicious/testing/kafka/junit5ext/Topic.java
@@ -13,7 +13,8 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
  * Signals the wish for a topic to be created and injected into a test as either test parameter
- * or field.
+ * or field. To customize the naming of the topic, parameters and fields of this type should be
+ * annotated with {@link TopicNameMethodSource}.
  * {@see KafkaClusterExtension}
  */
 public interface Topic {

--- a/junit5-extension/src/main/java/io/kroxylicious/testing/kafka/junit5ext/TopicNameMethodSource.java
+++ b/junit5-extension/src/main/java/io/kroxylicious/testing/kafka/junit5ext/TopicNameMethodSource.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.testing.kafka.junit5ext;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * {@link TopicNameMethodSource} is used to customize topic naming. It may be applied to the {@link Topic} type.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.FIELD, ElementType.PARAMETER })
+public @interface TopicNameMethodSource {
+
+    /**
+     * The name of the {@code static}, package- or {@code public}-accessible method.
+     * Defaults to 'topicName'.
+     * @return the string
+     */
+    String value() default "topicName";
+
+    /**
+     * The class where defining the static method, or Void.class (default), if the method
+     * is defined with the class defining the annotation test.
+     * @return the class
+     */
+    Class<?> clazz() default Void.class;
+
+}

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/AbstractExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/AbstractExtensionTest.java
@@ -23,6 +23,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.STRING;
 
 public abstract class AbstractExtensionTest {
+    public static final String ANOTHER_FIXED_TOPIC_NAME = "superTopic";
+
     public static boolean zookeeperAvailable() {
         try {
             Class.forName("kafka.server.KafkaServer");
@@ -63,5 +65,10 @@ public abstract class AbstractExtensionTest {
 
     protected <K, V> void doProducer(Producer<K, V> producer, K key, V value) throws ExecutionException, InterruptedException {
         producer.send(new ProducerRecord<>("my-topic", key, value)).get();
+    }
+
+    @SuppressWarnings("unused") // used via @TopicNameMethodSource
+    static String anotherCustomTopicName() {
+        return ANOTHER_FIXED_TOPIC_NAME;
     }
 }

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/InstanceFieldExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/InstanceFieldExtensionTest.java
@@ -31,6 +31,8 @@ import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 @ExtendWith(KafkaClusterExtension.class)
 class InstanceFieldExtensionTest extends AbstractExtensionTest {
 
+    public static final String FIXED_TOPIC_NAME = "fixed";
+    public static final String CUSTOM_TOPIC_NAME = "customTopic";
     @BrokerCluster(numBrokers = 1)
     KafkaCluster instanceCluster;
 
@@ -43,6 +45,22 @@ class InstanceFieldExtensionTest extends AbstractExtensionTest {
     Admin injectedAdmin;
 
     Topic injectedTopic;
+
+    @SuppressWarnings("unused") // used via @TopicNameMethodSource
+    static String topicName() {
+        return FIXED_TOPIC_NAME;
+    }
+
+    @TopicNameMethodSource
+    Topic topicWithCustomName;
+
+    @SuppressWarnings("unused") // used via @TopicNameMethodSource
+    String customTopicName() {
+        return CUSTOM_TOPIC_NAME;
+    }
+
+    @TopicNameMethodSource(clazz = AbstractExtensionTest.class, value = "anotherCustomTopicName")
+    Topic topicWithCustomNameFromOtherClass;
 
     private Admin privateField;
 
@@ -83,6 +101,20 @@ class InstanceFieldExtensionTest extends AbstractExtensionTest {
         ObjectAssert<Topic> topicAssert = assertThat(injectedTopic)
                 .isNotNull();
         topicAssert.extracting(Topic::name).isNotNull();
+        topicAssert.extracting(Topic::topicId, OPTIONAL).isNotNull().isNotEmpty();
+    }
+
+    @Test
+    void shouldInjectTopicFieldWithCustomName() {
+        ObjectAssert<Topic> topicAssert = assertThat(topicWithCustomName)
+                .isNotNull();
+        topicAssert.extracting(Topic::topicId, OPTIONAL).isNotNull().isNotEmpty();
+    }
+
+    @Test
+    void shouldInjectTopicFieldWithCustomNameFromOtherClass() {
+        ObjectAssert<Topic> topicAssert = assertThat(topicWithCustomNameFromOtherClass)
+                .isNotNull();
         topicAssert.extracting(Topic::topicId, OPTIONAL).isNotNull().isNotEmpty();
     }
 

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/KafkaClusterExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/KafkaClusterExtensionTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.testing.kafka.junit5ext;
+
+import java.util.stream.Stream;
+
+import org.apache.kafka.common.internals.Topic;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension.TopicNaming;
+import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension.TopicNaming.RandomHumanReadable;
+import io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension.TopicNaming.ReflectiveFactoryMethod;
+
+import static io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtensionTest.Another.ANOTHER_TOPIC_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doReturn;
+
+@ExtendWith(MockitoExtension.class)
+class KafkaClusterExtensionTest {
+
+    public static final String STATIC_TOPIC_NAME = "topicName";
+    public static final String INSTANCE_TOPIC_NAME = "instance";
+    @Mock
+    ExtensionContext extensionContext;
+
+    public static Stream<Arguments> testClassAndDefault() {
+        return Stream.of(Arguments.argumentSet("explicit", KafkaClusterExtensionTest.class), Arguments.argumentSet("default", Void.class));
+    }
+
+    @Test
+    void randomHumanReadableName() {
+        RandomHumanReadable randomHumanReadable = new RandomHumanReadable();
+        String name = randomHumanReadable.name();
+        assertThat(name).isNotNull();
+        assertThatCode(() -> Topic.validate(name)).doesNotThrowAnyException();
+    }
+
+    @MethodSource("testClassAndDefault")
+    @ParameterizedTest
+    void staticMethodOnTestClassWithDefaultClass(Class<?> testClass) {
+        doReturn(this.getClass()).when(extensionContext).getRequiredTestClass();
+        TopicNaming topicNaming = new ReflectiveFactoryMethod(extensionContext, testClass, "staticTopicName");
+        assertThat(topicNaming.name()).isEqualTo(STATIC_TOPIC_NAME);
+    }
+
+    @Test
+    void staticMethodOnNonTestClass() {
+        doReturn(this.getClass()).when(extensionContext).getRequiredTestClass();
+        TopicNaming topicNaming = new ReflectiveFactoryMethod(extensionContext, Another.class, "topicName");
+        assertThat(topicNaming.name()).isEqualTo(ANOTHER_TOPIC_NAME);
+    }
+
+    @MethodSource("testClassAndDefault")
+    @ParameterizedTest
+    void nullReturnNotAllowed(Class<?> testClass) {
+        doReturn(this.getClass()).when(extensionContext).getRequiredTestClass();
+        TopicNaming topicNaming = new ReflectiveFactoryMethod(extensionContext, testClass, "invalidMethod_nullReturn");
+        assertThatThrownBy(topicNaming::name).isInstanceOf(ParameterResolutionException.class)
+                .hasMessage(
+                        "topic name source method static java.lang.String io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtensionTest.invalidMethod_nullReturn() returned null");
+    }
+
+    @MethodSource("testClassAndDefault")
+    @ParameterizedTest
+    void methodMustHaveZeroParameters(Class<?> testClass) {
+        doReturn(this.getClass()).when(extensionContext).getRequiredTestClass();
+        TopicNaming topicNaming = new ReflectiveFactoryMethod(extensionContext, testClass, "invalidMethod_hasParameter");
+        assertThatThrownBy(topicNaming::name).isInstanceOf(ParameterResolutionException.class)
+                .hasMessage("failed to invoke topic source name method invalidMethod_hasParameter of io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtensionTest");
+    }
+
+    @MethodSource("testClassAndDefault")
+    @ParameterizedTest
+    void methodMustReturnString(Class<?> testClass) {
+        doReturn(this.getClass()).when(extensionContext).getRequiredTestClass();
+        TopicNaming topicNaming = new ReflectiveFactoryMethod(extensionContext, testClass, "invalidMethod_notStringReturnType");
+        assertThatThrownBy(topicNaming::name).isInstanceOf(ParameterResolutionException.class)
+                .hasMessage(
+                        "topic name source method private static int io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtensionTest.invalidMethod_notStringReturnType() must return String");
+    }
+
+    @Test
+    void nonStaticMethodDisallowed() {
+        doReturn(this.getClass()).when(extensionContext).getRequiredTestClass();
+        TopicNaming topicNaming = new ReflectiveFactoryMethod(extensionContext, Another.class, "instanceMethod");
+        assertThatThrownBy(topicNaming::name).isInstanceOf(ParameterResolutionException.class)
+                .hasMessage(
+                        "topic name source method java.lang.String io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtensionTest$Another.instanceMethod() is not static.");
+    }
+
+    public static Stream<Arguments> reflectiveFactoryMethodConstructorArgsMustBeNonNull() {
+        ExtensionContext context = Mockito.mock(ExtensionContext.class);
+        return Stream.of(Arguments.argumentSet("null context", (Runnable) () -> {
+            new ReflectiveFactoryMethod(null, Void.class, "method");
+        }, "context must not be null"),
+                Arguments.argumentSet("null methodClass", (Runnable) () -> {
+                    new ReflectiveFactoryMethod(context, null, "method");
+                }, "methodClass must not be null"),
+                Arguments.argumentSet("null method", (Runnable) () -> {
+                    new ReflectiveFactoryMethod(context, Void.class, null);
+                }, "method must not be null"));
+    }
+
+    @MethodSource
+    @ParameterizedTest
+    void reflectiveFactoryMethodConstructorArgsMustBeNonNull(Runnable runnable, String errorMessage) {
+        assertThatThrownBy(runnable::run).isInstanceOf(NullPointerException.class).hasMessage(errorMessage);
+    }
+
+    @SuppressWarnings("unused") // used reflectively
+    static String staticTopicName() {
+        return STATIC_TOPIC_NAME;
+    }
+
+    @SuppressWarnings("unused") // used reflectively
+    static String invalidMethod_nullReturn() {
+        return null;
+    }
+
+    @SuppressWarnings("unused") // used reflectively
+    private static int invalidMethod_notStringReturnType() {
+        throw new IllegalStateException("should never be invoked");
+    }
+
+    @SuppressWarnings("unused") // used reflectively
+    static String invalidMethod_hasParameter(int ignored) {
+        throw new IllegalStateException("should never be invoked");
+    }
+
+    @SuppressWarnings("unused")
+    // used reflectively
+    String instanceTopicName() {
+        throw new IllegalStateException("should never be invoked");
+    }
+
+    public record Another() {
+
+        public static final String ANOTHER_TOPIC_NAME = "another";
+
+        @SuppressWarnings("unused") // used reflectively
+        static String topicName() {
+            return ANOTHER_TOPIC_NAME;
+        }
+
+        @SuppressWarnings("unused")
+        // used reflectively
+        String instanceMethod() {
+            throw new IllegalStateException("should never be invoked");
+        }
+    }
+
+}


### PR DESCRIPTION
### Type of change

- Enhancement / new feature

### Description

Users can annotate a Topic parameter or field with an `@TopicNameMethodSource` to customize the topic naming.

Following the other method source annotations users can supply:
1. `clazz` which points at the class carrying the method to invoke. The
   default value is Void which implies that we target the Test class.
2. `value` which is the name of the method. It must have no arguments
   and return String. It must be static.

Then, when the extension is automatically creating topics the user has requested, this method will be invoked to retrieve the topic name.

This enables users to control the topic naming for cases where the length and characters in the topic name have some restrictions differing from the default automatic naming convention.

The immediate driver is that in kroxylicious/kroxylicious we want to arrange things such that the topic names created for some tests also happen to be valid Key Names in Azure Key Vault.

This replaces #517 

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
