### PR TITLE
deps: Upgrade to Kafka 4.3.0

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -89,7 +89,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        version: [3.8.0,3.9.0,4.0.0,4.1.0,4.2.0]
+        version: [3.8.0,3.9.0,4.0.0,4.1.0,4.2.0,4.3.0]
     steps:
       - name: 'Check out repository'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Please enumerate all user-facing changes using format `<githib issue/pr number>: <short description>`, with changes ordered in reverse chronological order.
 
 ## SNAPSHOT
+
+* [#568](https://github.com/kroxylicious/kroxylicious-junit5-extension/pull/616): deps: Upgrade to Kafka 4.3.0
+
 ## 0.15.0
 
 * [#568](https://github.com/kroxylicious/kroxylicious-junit5-extension/issues/568): Upgrade to kafka-4.2.0

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/clients/MethodUtils.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/clients/MethodUtils.java
@@ -23,10 +23,11 @@ final class MethodUtils {
         // do not construct
     }
 
-    static Stream<Method> delegatedMethods(Class<?> adminClass) {
-        return Arrays.stream(adminClass.getMethods())
+    static Stream<Method> delegatedMethods(Class<?> clazz) {
+        return Arrays.stream(clazz.getMethods())
                 .filter(method -> !Modifier.isStatic(method.getModifiers()) &&
                         !method.isSynthetic() &&
+                        !method.isDefault() &&
                         !method.getName().equals("close"));
     }
 

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaClusterTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaClusterTest.java
@@ -231,7 +231,7 @@ class TestcontainersKafkaClusterTest {
     }
 
     private static Stream<Version> fixedVersionsPost41() {
-        return Stream.of(version("4.1.0"), version("4.1.1"), version("4.2.0"));
+        return Stream.of(version("4.1.0"), version("4.1.1"), version("4.2.0"), version("4.3.0"));
     }
 
     private static Stream<Version> allVersionsWithAlterScramSupport() {

--- a/integration-test/src/test/java/io/kroxylicious/testing/kafka/junit5ext/TestcontainersTest.java
+++ b/integration-test/src/test/java/io/kroxylicious/testing/kafka/junit5ext/TestcontainersTest.java
@@ -50,6 +50,12 @@ class TestcontainersTest {
     }
 
     @Test
+    void test43(@Version("4.3.0") TestcontainersKafkaCluster cluster) throws ExecutionException, InterruptedException, TimeoutException {
+        String clusterId = cluster.createAdmin().describeCluster().clusterId().get(10, TimeUnit.SECONDS);
+        assertThat(clusterId).isNotEmpty();
+    }
+
+    @Test
     void testLatest(@Version(Version.LATEST_RELEASE) TestcontainersKafkaCluster cluster) throws ExecutionException, InterruptedException, TimeoutException {
         String clusterId = cluster.createAdmin().describeCluster().clusterId().get(10, TimeUnit.SECONDS);
         assertThat(clusterId).isNotEmpty();

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/TemplateTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/TemplateTest.java
@@ -190,6 +190,7 @@ class TemplateTest {
     private static Stream<Version> versions() {
         return Stream.of(
                 version(Version.LATEST_RELEASE),
+                version("4.3.0"),
                 version("4.2.0"),
                 version("4.1.0"),
                 version("3.9.0"),

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
         <skipUTs>${skipTests}</skipUTs>
 
         <junit.version>5.14.4</junit.version>
-        <kafka.version>4.2.0</kafka.version>
+        <kafka.version>4.3.0</kafka.version>
         <testcontainers.version>2.0.5</testcontainers.version>
         <lombok.version>1.18.46</lombok.version>
         <assertj-core.version>3.27.7</assertj-core.version>


### PR DESCRIPTION
## Summary

Updates to Kafka 4.3.0.


## Changes

### Build Configuration
- ⬆️ Update `kafka.version` from `4.2.0` to `4.3.0`

### Test Updates
- ✅ Add `4.3.0` to version test axes in `TemplateTest`
- ✅ Add `4.3.0` to GitHub Actions CI matrix

### Compatibility Fix
- 🔧 **Fix mock delegation tests** in `MethodUtils.java` to filter default methods (`!method.isDefault()`)
  - **Why:** Kafka 4.3.0 added default methods to Admin/Consumer/Producer interfaces that delegate to overloaded versions with `*Options` parameters
  - **Impact:** Without this fix, Mockito's strict stubbing detects multiple method invocations and fails

## Kafka 4.3.0 Changes Affecting the Extension

### Breaking/Impactful Changes

1. **New Default Methods in Client Interfaces** ✅ Fixed
   - Admin, Consumer, Producer got default methods delegating to `*Options` overloads
   - Example: `Admin.updateFeatures(Map)` now delegates to `updateFeatures(Map, UpdateFeaturesOptions)`
   - Fixed by filtering `isDefault()` in mock delegation tests

2. **Deprecated APIs** ⚠️ Warning Only
   - `Consumer#close(Duration)` → `Consumer#close(CloseOptions)`
   - Extension uses deprecated method - still works but should migrate eventually
   - Not urgent - can be updated before Kafka 5.0

3. **Consumer Behavior Clarifications** 📝
   - `assignment()`/`subscription()` documented as returning snapshots (always did, now explicit)
   - No code changes needed

### Bug Fixes in 4.3 That Improve Testing

- **KAFKA-19542**: Consumer.close() now properly removes all sensors from Metrics (better test isolation)
- **KAFKA-20165**: Consumer poll may throw KafkaException if topic not in metadata (more strict)
- **KAFKA-20426**: Fixed busy loop when using both `group.id` and `assign()`
- **KAFKA-20428**: Fixed unsubscribe failures during assignment processing

### New Features (Additive)

- Share group configs: `share.delivery.count.limit`, `share.partition.max.record.locks`, `share.renew.acknowledge.enable`
- State store header support (KIP-1066)
- Group coordinator thread pool config


## References

- [Kafka 4.3.0-RC2 Release Notes](https://dist.apache.org/repos/dist/dev/kafka/4.3.0-rc2/RELEASE_NOTES.html)
- [KIP-932: Queues for Kafka (Share Groups)](https://cwiki.apache.org/confluence/display/KAFKA/KIP-932:+Queues+for+Kafka)
- [Apache Kafka 4.3.0-RC2 Vote Thread](https://lists.apache.org/thread/hb5jw1nwor58ch8dgthmdl3gryoqj5vt)