### PR TITLE
chore(build): refine checkstyle rules for JSR305 annotation ban

### DIFF
--- a/etc/checkstyle-custom_checks.xml
+++ b/etc/checkstyle-custom_checks.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<!--
+
+    Copyright Kroxylicious Authors.
+
+    Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+<!DOCTYPE module PUBLIC
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+
+    <module name="TreeWalker">
+        <module name="IllegalImport">
+            <property name="regexp" value="true"/>
+            <!-- ban jsr305 annotations - we use spotbugs annotations instead -->
+            <!-- Note: javax.annotation.processing is allowed (standard Java annotation processing API) -->
+            <property name="illegalClasses" value="^javax\.annotation\.(?!processing\.).*"/>
+        </module>
+
+        <!-- Ban fully qualified uses of jsr305 annotations (catches cases without imports) -->
+        <!-- Negative lookahead (?!processing\.) allows javax.annotation.processing.* which is standard Java -->
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="javax\.annotation\.(?!processing\.)(concurrent\.)?" />
+            <property name="message" value="Do not use jsr305 annotations (javax.annotation.*). Use spotbugs annotations (e.g. edu.umd.cs.findbugs.annotations.Nullable) instead." />
+        </module>
+    </module>
+
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -463,6 +463,25 @@
                     <version>${jacoco-maven-plugin.version}</version>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <version>3.6.0</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>com.puppycrawl.tools</groupId>
+                            <artifactId>checkstyle</artifactId>
+                            <version>10.26.1</version>
+                        </dependency>
+                    </dependencies>
+                    <configuration>
+                        <!--suppress MavenModelInspection -->
+                        <configLocation>${session.executionRootDirectory}/etc/checkstyle-custom_checks.xml</configLocation>
+                        <consoleOutput>true</consoleOutput>
+                        <failsOnError>true</failsOnError>
+                        <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                    </configuration>
+                </plugin>
+                <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
                     <version>3.6.1</version>
@@ -514,6 +533,19 @@
                     <plugin>
                         <groupId>net.revelc.code</groupId>
                         <artifactId>impsort-maven-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-checkstyle-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>validate</id>
+                                <phase>validate</phase>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
                     </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Summary

Add checkstyle configuration to prevent use of JSR305 annotations (`javax.annotation.*`) while allowing standard Java annotation processing API (`javax.annotation.processing.*`).

## Changes

- Created `etc/checkstyle-custom_checks.xml` with:
  - `IllegalImport` rule using regex to block `javax.annotation.*` imports (except `javax.annotation.processing.*`)
  - `RegexpSinglelineJava` rule to catch fully qualified JSR305 annotation usage
  
- Updated `pom.xml` to add `maven-checkstyle-plugin` v3.6.0 with checkstyle v10.26.1
  - Configured to run in the `qa` profile during `validate` phase
  - Checks both main and test source directories

## Rationale

This aligns with the main Kroxylicious repository's approach (see [kroxylicious#3972](https://github.com/kroxylicious/kroxylicious/pull/3972)) of using SpotBugs annotations instead of JSR305.

## Test Plan

- ✅ `mvn checkstyle:check` passes
- ✅ `mvn clean verify -DskipTests` passes
- ✅ No existing code uses JSR305 annotations (project already uses SpotBugs annotations)

Fixes #615