### PR TITLE
Increase randomness of default topic naming strategy

### DIFF
--- a/junit5-extension/src/main/java/io/kroxylicious/testing/kafka/junit5ext/KafkaClusterExtension.java
+++ b/junit5-extension/src/main/java/io/kroxylicious/testing/kafka/junit5ext/KafkaClusterExtension.java
@@ -28,6 +28,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -36,6 +37,7 @@ import java.util.stream.Stream;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.admin.TopicListing;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -67,6 +69,7 @@ import org.apache.kafka.common.serialization.VoidDeserializer;
 import org.apache.kafka.common.serialization.VoidSerializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.awaitility.Awaitility;
+import org.awaitility.core.TerminalFailureException;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
@@ -99,6 +102,7 @@ import io.kroxylicious.testing.kafka.internal.AdminSource;
 import io.kroxylicious.testing.kafka.invm.InVMKafkaCluster;
 import io.kroxylicious.testing.kafka.testcontainers.TestcontainersKafkaCluster;
 
+import static java.lang.System.Logger.Level.ERROR;
 import static java.lang.System.Logger.Level.TRACE;
 import static org.apache.kafka.common.internals.Topic.validate;
 import static org.junit.platform.commons.support.ReflectionSupport.findFields;
@@ -186,7 +190,8 @@ public class KafkaClusterExtension implements
         record RandomHumanReadable() implements TopicNaming {
             @Override
             public String name() {
-                return MobyNamesGenerator.getRandomName();
+                // MobyNamesGenerator only has 25K unique outputs, chance of collisions is too high, so we add a random UUID on
+                return MobyNamesGenerator.getRandomName() + "_" + UUID.randomUUID();
             }
         }
 
@@ -1087,19 +1092,45 @@ public class KafkaClusterExtension implements
                 var numPartitions = Optional.ofNullable(sourceElement.getAnnotation(TopicPartitions.class)).map(TopicPartitions::value);
                 var replicationFactor = Optional.ofNullable(sourceElement.getAnnotation(TopicReplicationFactor.class)).map(TopicReplicationFactor::value);
                 var topicDef = new NewTopic(topicName, numPartitions, replicationFactor).configs(buildTopicConfig(sourceElement));
-                CreateTopicsResult topicsResult = admin.createTopics(List.of(topicDef));
-                var createFuture = topicsResult.all();
-
-                var topicMap = Awaitility.await()
-                        .failFast(createFuture::isCompletedExceptionally)
-                        .atMost(Duration.ofSeconds(5))
-                        .until(() -> admin.listTopics().namesToListings().get(),
-                                n -> n.containsKey(topicName));
+                Map<String, TopicListing> topicMap = executeTopicCreate(admin, topicDef, topicName);
                 return new KafkaTopic(topicName, topicMap.get(topicName).topicId());
             }
         }
         else {
             throw new UnsupportedOperationException("Kafka cluster " + cluster.getClass() + " does not support producing an anonymous admin client.");
+        }
+    }
+
+    @VisibleForTesting
+    static Map<String, TopicListing> executeTopicCreate(Admin admin, NewTopic topicDef, String topicName) {
+        CreateTopicsResult topicsResult = admin.createTopics(List.of(topicDef));
+        var createFuture = topicsResult.all();
+        try {
+            return Awaitility.await()
+                    .failFast(createFuture::isCompletedExceptionally)
+                    .atMost(Duration.ofSeconds(5))
+                    .until(() -> admin.listTopics().namesToListings().get(),
+                            n -> n.containsKey(topicName));
+        }
+        catch (TerminalFailureException exception) {
+            if (createFuture.isCompletedExceptionally()) {
+                try {
+                    // at language level 19 we could change to exceptionNow to avoid interrupt handling
+                    createFuture.getNow(null);
+                }
+                catch (ExecutionException e) {
+                    exception.addSuppressed(e);
+                }
+                catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    exception.addSuppressed(e);
+                }
+            }
+            else {
+                createFuture.cancel(true);
+            }
+            LOGGER.log(ERROR, "test {0}: failed to create topic", exception);
+            throw exception;
         }
     }
 

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/KafkaClusterExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/KafkaClusterExtensionTest.java
@@ -5,9 +5,21 @@
  */
 package io.kroxylicious.testing.kafka.junit5ext;
 
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.CreateTopicsResult;
+import org.apache.kafka.clients.admin.ListTopicsResult;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.admin.TopicListing;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.errors.TopicExistsException;
+import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.apache.kafka.common.internals.Topic;
+import org.awaitility.core.TerminalFailureException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -27,7 +39,11 @@ import static io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtensionTest.
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class KafkaClusterExtensionTest {
@@ -47,6 +63,14 @@ class KafkaClusterExtensionTest {
         String name = randomHumanReadable.name();
         assertThat(name).isNotNull();
         assertThatCode(() -> Topic.validate(name)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void randomHumanReadableNameHighlyUnique() {
+        RandomHumanReadable randomHumanReadable = new RandomHumanReadable();
+        int generateCount = 1000000;
+        long unique = IntStream.range(0, generateCount).boxed().map(integer -> randomHumanReadable.name()).distinct().count();
+        assertThat(unique).isEqualTo(generateCount);
     }
 
     @MethodSource("testClassAndDefault")
@@ -145,6 +169,80 @@ class KafkaClusterExtensionTest {
     // used reflectively
     String instanceTopicName() {
         throw new IllegalStateException("should never be invoked");
+    }
+
+    @Test
+    void executeTopicCreateSuppressesCreateFailureCause() {
+        Admin admin = mock(Admin.class);
+        CreateTopicsResult createResult = mock(CreateTopicsResult.class);
+        KafkaFutureImpl<Void> failedFuture = new KafkaFutureImpl<>();
+        var cause = new TopicExistsException("already exists");
+        failedFuture.completeExceptionally(cause);
+        when(admin.createTopics(any())).thenReturn(createResult);
+        when(createResult.all()).thenReturn(failedFuture);
+        stubListTopics(admin);
+
+        var topicDef = new NewTopic("test", 1, (short) 1);
+        assertThatThrownBy(() -> KafkaClusterExtension.executeTopicCreate(admin, topicDef, "test"))
+                .isInstanceOf(TerminalFailureException.class)
+                .satisfies(ex -> assertThat(ex.getSuppressed())
+                        .singleElement()
+                        .isInstanceOf(ExecutionException.class)
+                        .extracting(Throwable::getCause)
+                        .isEqualTo(cause));
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void executeTopicCreateRestoresInterruptFlagOnInterruptedException() throws Exception {
+        try {
+            Admin admin = mock(Admin.class);
+            CreateTopicsResult createResult = mock(CreateTopicsResult.class);
+            KafkaFuture<Void> mockFuture = mock(KafkaFuture.class);
+            when(mockFuture.isCompletedExceptionally()).thenReturn(true);
+            when(mockFuture.getNow(null)).thenThrow(new InterruptedException("test interrupt"));
+            when(admin.createTopics(any())).thenReturn(createResult);
+            when(createResult.all()).thenReturn(mockFuture);
+            stubListTopics(admin);
+
+            var topicDef = new NewTopic("test", 1, (short) 1);
+            assertThatThrownBy(() -> KafkaClusterExtension.executeTopicCreate(admin, topicDef, "test"))
+                    .isInstanceOf(TerminalFailureException.class)
+                    .satisfies(ex -> assertThat(ex.getSuppressed())
+                            .singleElement()
+                            .isInstanceOf(InterruptedException.class));
+            assertThat(Thread.interrupted()).as("interrupt flag should be restored").isTrue();
+        }
+        finally {
+            Thread.interrupted();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    void executeTopicCreateCancelsFutureWhenNotCompletedExceptionally() {
+        Admin admin = mock(Admin.class);
+        CreateTopicsResult createResult = mock(CreateTopicsResult.class);
+        KafkaFuture<Void> mockFuture = mock(KafkaFuture.class);
+        when(mockFuture.isCompletedExceptionally()).thenReturn(true, false);
+        when(admin.createTopics(any())).thenReturn(createResult);
+        when(createResult.all()).thenReturn(mockFuture);
+        stubListTopics(admin);
+
+        var topicDef = new NewTopic("test", 1, (short) 1);
+        assertThatThrownBy(() -> KafkaClusterExtension.executeTopicCreate(admin, topicDef, "test"))
+                .isInstanceOf(TerminalFailureException.class)
+                .satisfies(ex -> assertThat(ex.getSuppressed()).isEmpty());
+
+        verify(mockFuture).cancel(true);
+    }
+
+    private static void stubListTopics(Admin admin) {
+        ListTopicsResult listResult = mock(ListTopicsResult.class);
+        KafkaFutureImpl<Map<String, TopicListing>> listFuture = new KafkaFutureImpl<>();
+        listFuture.complete(Map.of());
+        Mockito.lenient().when(admin.listTopics()).thenReturn(listResult);
+        Mockito.lenient().when(listResult.namesToListings()).thenReturn(listFuture);
     }
 
     public record Another() {


### PR DESCRIPTION


### Type of change

- Bugfix

### Description

The MobyNamesGenerator only selects from 25K random values. 

So for a test that uses 3 topics there is:
`1/(1 - (25596/25596 * 25595/25596 * 25594/25596)) = ~8532`. A roughly 1 in 8500 chance of a collision. So magnify this by all the tests which create a few topics and collisions are bound to happen every so often.

Instead we can tack on a UUID. I think this will keep the desired human readability at the front, with guaranteed uniqueness at the back.

We also log if there is a problem during topic creation.

I tested by hardcoding the random topic name to force a duplicate name failure, which leads to the parameter resolution failing with the suppressed exception visible:

```
org.junit.jupiter.api.extension.ParameterResolutionException: Failed to resolve parameter [io.kroxylicious.testing.kafka.junit5ext.Topic topic2] in method [void io.kroxylicious.testing.kafka.junit5ext.ParameterExtensionTest.topic(io.kroxylicious.testing.kafka.api.KafkaCluster,io.kroxylicious.testing.kafka.junit5ext.Topic,io.kroxylicious.testing.kafka.junit5ext.Topic,org.apache.kafka.clients.admin.Admin) throws java.lang.Exception]: Fail fast condition triggered

	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
Caused by: org.awaitility.core.TerminalFailureException: Fail fast condition triggered
	at org.awaitility.core.ConditionAwaiter.executeFailFastConditionIfDefined(ConditionAwaiter.java:194)
	at org.awaitility.core.ConditionAwaiter.await(ConditionAwaiter.java:97)
	at org.awaitility.core.AbstractHamcrestCondition.await(AbstractHamcrestCondition.java:86)
	at org.awaitility.core.ConditionFactory.until(ConditionFactory.java:1160)
	at org.awaitility.core.ConditionFactory.until(ConditionFactory.java:712)
	at org.awaitility.core.ConditionFactory.until(ConditionFactory.java:729)
	at io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension.executeTopicCreate(KafkaClusterExtension.java:1111)
	at io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension.createTopic(KafkaClusterExtension.java:1095)
	at io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension.resolveParameter(KafkaClusterExtension.java:602)
	at io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension.resolveParameter(KafkaClusterExtension.java:554)
	... 2 more
	Suppressed: java.util.concurrent.ExecutionException: org.apache.kafka.common.errors.TopicExistsException: Topic 'test' already exists.
		at org.apache.kafka.common.internals.KafkaFutureImpl.getNow(KafkaFutureImpl.java:205)
		at io.kroxylicious.testing.kafka.junit5ext.KafkaClusterExtension.executeTopicCreate(KafkaClusterExtension.java:1117)
		... 5 more
	Caused by: org.apache.kafka.common.errors.TopicExistsException: Topic 'test' already exists.
```

Closes #570

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] Update CHANGELOG.md
