### PR TITLE
Skip docker-dependent tests when there is no docker

### DIFF
--- a/impl/src/test/java/io/kroxylicious/testing/kafka/common/KafkaClusterFactoryTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/common/KafkaClusterFactoryTest.java
@@ -5,7 +5,9 @@
  */
 package io.kroxylicious.testing.kafka.common;
 
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
+import org.testcontainers.DockerClientFactory;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -14,6 +16,8 @@ class KafkaClusterFactoryTest {
     @SuppressWarnings("resource")
     @Test
     void shouldCreateInstanceInContainerModeWithControllerOnlyNodes() throws Exception {
+        Assumptions.assumeTrue(DockerClientFactory.instance().isDockerAvailable(), "Docker/Podman not available");
+
         // Given
         final KafkaClusterConfig kafkaClusterConfig = KafkaClusterConfig.builder()
                 .execMode(KafkaClusterExecutionMode.CONTAINER)

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaClusterTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/testcontainers/TestcontainersKafkaClusterTest.java
@@ -19,6 +19,8 @@ import org.apache.kafka.common.config.SaslConfigs;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.AppInfoParser;
 import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
@@ -26,6 +28,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junitpioneer.jupiter.ClearEnvironmentVariable;
 import org.junitpioneer.jupiter.SetEnvironmentVariable;
+import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.images.RemoteDockerImage;
 import org.testcontainers.utility.DockerImageName;
@@ -42,6 +45,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ClearEnvironmentVariable(key = TestcontainersKafkaCluster.LEGACY_ZOOKEEPER_IMAGE_REPO)
 @ClearEnvironmentVariable(key = TestcontainersKafkaCluster.LEGACY_ZOOKEEPER_IMAGE_TAG)
 class TestcontainersKafkaClusterTest {
+
+    @BeforeAll
+    static void assumeDockerAvailable() {
+        Assumptions.assumeTrue(DockerClientFactory.instance().isDockerAvailable(), "Docker/Podman not available");
+    }
 
     private KafkaClusterConfig.KafkaClusterConfigBuilder clusterConfigBuilder;
 

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/ParameterExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/ParameterExtensionTest.java
@@ -11,6 +11,8 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
+import io.kroxylicious.testing.kafka.common.KafkaClusterExecutionMode;
+
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ConfigEntry;
@@ -70,7 +72,7 @@ class ParameterExtensionTest extends AbstractExtensionTest {
 
     @BeforeEach
     void assumeDockerAvailableWhenContainerModeForced() {
-        if ("CONTAINER".equals(System.getenv(KafkaClusterFactory.TEST_CLUSTER_EXECUTION_MODE))) {
+        if (KafkaClusterExecutionMode.CONTAINER.name().equals(System.getenv(KafkaClusterFactory.TEST_CLUSTER_EXECUTION_MODE))) {
             Assumptions.assumeTrue(DockerClientFactory.instance().isDockerAvailable(), "Docker/Podman not available");
         }
     }

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/ParameterExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/ParameterExtensionTest.java
@@ -31,10 +31,13 @@ import org.apache.kafka.common.errors.SaslAuthenticationException;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.assertj.core.api.ObjectAssert;
 import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junitpioneer.jupiter.SetEnvironmentVariable;
+import org.testcontainers.DockerClientFactory;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -64,6 +67,14 @@ import static org.awaitility.Awaitility.await;
 class ParameterExtensionTest extends AbstractExtensionTest {
 
     private static final Duration CLUSTER_FORMATION_TIMEOUT = Duration.ofSeconds(10);
+
+    @BeforeEach
+    void assumeDockerAvailableWhenContainerModeForced() {
+        if ("CONTAINER".equals(System.getenv(KafkaClusterFactory.TEST_CLUSTER_EXECUTION_MODE))) {
+            Assumptions.assumeTrue(DockerClientFactory.instance().isDockerAvailable(), "Docker/Podman not available");
+        }
+    }
+
     private static final String CONSUMER_GROUP = "mygroup";
     private static final String TRANSACTIONAL_ID = "mytxn1";
     private static final String CLIENT_ID = "myclientid";

--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/ParameterExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/ParameterExtensionTest.java
@@ -11,8 +11,6 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
-import io.kroxylicious.testing.kafka.common.KafkaClusterExecutionMode;
-
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ConfigEntry;
@@ -48,6 +46,7 @@ import io.kroxylicious.testing.kafka.common.BrokerCluster;
 import io.kroxylicious.testing.kafka.common.BrokerConfig;
 import io.kroxylicious.testing.kafka.common.ClientConfig;
 import io.kroxylicious.testing.kafka.common.KRaftCluster;
+import io.kroxylicious.testing.kafka.common.KafkaClusterExecutionMode;
 import io.kroxylicious.testing.kafka.common.KafkaClusterFactory;
 import io.kroxylicious.testing.kafka.common.SaslMechanism;
 import io.kroxylicious.testing.kafka.common.SaslMechanism.Principal;


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Skip some tests if docker/podman is not available. 

The value of this one is debatable. It was helpful to me when a sandboxed claude runs the tests and reports about failing tests which are only failing because of the lack of docker within the sandbox.

