### PR TITLE
fix(test): re-query cluster metadata in assertClusterIdAndSize

### DIFF
--- a/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/ParameterExtensionTest.java
+++ b/junit5-extension/src/test/java/io/kroxylicious/testing/kafka/junit5ext/ParameterExtensionTest.java
@@ -455,14 +455,13 @@ class ParameterExtensionTest extends AbstractExtensionTest {
                 .succeedsWithin(Duration.ofSeconds(10), STRING)
                 .isEqualTo(cluster.getClusterId());
 
-        await().atMost(CLUSTER_FORMATION_TIMEOUT).untilAsserted(() -> assertThat(dc.nodes())
+        await().atMost(CLUSTER_FORMATION_TIMEOUT).untilAsserted(() -> assertThat(describeCluster(cluster.getKafkaClientConfiguration()).nodes())
                 .succeedsWithin(Duration.ofSeconds(10))
                 .asInstanceOf(collection(Node.class)).hasSize(expectedNodes));
     }
 
     private void assertClusterSize(KafkaCluster cluster, int expectedNodes) throws Exception {
-        var dc = describeCluster(cluster.getKafkaClientConfiguration());
-        await().atMost(CLUSTER_FORMATION_TIMEOUT).untilAsserted(() -> assertThat(dc.nodes())
+        await().atMost(CLUSTER_FORMATION_TIMEOUT).untilAsserted(() -> assertThat(describeCluster(cluster.getKafkaClientConfiguration()).nodes())
                 .succeedsWithin(Duration.ofSeconds(10))
                 .asInstanceOf(collection(Node.class)).hasSize(expectedNodes));
     }


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The previous implementation captured a single `DescribeClusterResult` before the `await()` loop and then checked `dc.nodes()` repeatedly inside it. Because `dc.nodes()` returns the same already-resolved `KafkaFuture` on every call, the loop never re-fetched cluster state from the broker, so a second broker that hadn't registered at the time of the first call was never seen.

Fix both `assertClusterIdAndSize` and `assertClusterSize` to call `describeCluster()` fresh inside the `untilAsserted` lambda so each poll issues a new metadata request against the live cluster.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>


