### PR TITLE
ci(sonar): opt in to unsafe PR checkout for fork PRs

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -45,6 +45,7 @@ jobs:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_branch }}
           fetch-depth: 0
+          allow-unsafe-pr-checkout: true
 
       - name: Checkout base branch
         run: |

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -45,6 +45,8 @@ jobs:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_branch }}
           fetch-depth: 0
+          # Fork PR code runs in the base repo's trusted context. We mitigate the pwn-request
+          # risk via approval-required settings on CI runs. See https://gh.io/securely-using-pull_request_target
           allow-unsafe-pr-checkout: true
 
       - name: Checkout base branch


### PR DESCRIPTION
## Summary

Sonar builds [are failing](https://github.com/kroxylicious/kroxylicious-junit5-extension/actions/runs/29783382373) with

> Error: Refusing to check out fork pull request code from a 'workflow_run' workflow. This workflow runs with the base repository's GITHUB_TOKEN, secrets, default-branch cache scope, and runner access. Fetching and executing a fork's code in that trusted context commonly leads to "pwn request" vulnerabilities. To opt in, review the risks at https://gh.io/securely-using-pull_request_target and set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.

- Sets `allow-unsafe-pr-checkout: true` on the `actions/checkout` step in the Sonar workflow
- The workflow uses `workflow_run` with the base repo token; `actions/checkout` now refuses to check out fork PR code in that context by default
- Risk is mitigated by approval-required settings on CI runs, as documented in the linked GitHub guidance https://gh.io/securely-using-pull_request_target

AI assisted: changes generated with Claude Sonnet 4.6.