### PR TITLE
build: upgrade Java target from 17 to 21

### DIFF
--- a/.github/actions/common/setup-java/action.yml
+++ b/.github/actions/common/setup-java/action.yml
@@ -22,7 +22,7 @@ inputs:
   javaVersion:
     description: "Java version to be installed"
     required: false
-    default: "17"
+    default: "21"
   javaDistro:
     description: "Java distribution to be installed"
     required: false

--- a/DEV_GUIDE.md
+++ b/DEV_GUIDE.md
@@ -19,7 +19,7 @@ This document gives a detailed breakdown of the various build processes and opti
 
 ## Build Prerequisites
 
-- [JDK](https://openjdk.org/projects/jdk/17/) (version 17 and above) - Maven CLI
+- [JDK](https://openjdk.org/projects/jdk/21/) (version 21 and above) - Maven CLI
 - [`mvn`](https://maven.apache.org/index.html) (version 3.5 and above) - Maven CLI
 - [`docker`](https://docs.docker.com/install/) or [`podman`](https://podman.io/docs/installation) - Docker or Podman
 
@@ -27,7 +27,7 @@ This document gives a detailed breakdown of the various build processes and opti
 > 
 ## JDK target
 
-The project targets language Java level 17.
+The project targets language Java level 21.
 
 ## Building / Running the Tests
 

--- a/pom.xml
+++ b/pom.xml
@@ -71,8 +71,8 @@
     </modules>
 
     <properties>
-        <java.version>17</java.version>
-        <java.test.version>17</java.test.version>
+        <java.version>21</java.version>
+        <java.test.version>21</java.test.version>
         <maven.compiler.parameters>true</maven.compiler.parameters>
         <maven.compiler.release>${java.version}</maven.compiler.release>
         <maven.compiler.testRelease>${java.test.version}</maven.compiler.testRelease>


### PR DESCRIPTION
### Type of change

_Select the type of your PR_

- Enhancement / new feature

### Description

Update maven.compiler.release, CI setup-java default, and documentation to target Java 21.

Assisted-by: Claude Sonnet 4.6 <noreply@anthropic.com>