### PR TITLE
fix(test): bootstrap SCRAM credentials at KRaft format time

### DIFF
--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/InVMKafkaCluster.java
@@ -14,6 +14,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
@@ -57,6 +58,7 @@ public class InVMKafkaCluster implements KafkaCluster, KafkaListenerSource, Admi
 
     private final KafkaClusterConfig clusterConfig;
     private final Path tempDirectory;
+    private final List<String> scramArguments;
     private ZooKeeperServer zooServer;
 
     /**
@@ -79,6 +81,9 @@ public class InVMKafkaCluster implements KafkaCluster, KafkaListenerSource, Admi
      */
     public InVMKafkaCluster(KafkaClusterConfig clusterConfig) {
         this.clusterConfig = clusterConfig;
+        this.scramArguments = clusterConfig.isKraftMode() && clusterConfig.isSaslScram()
+                ? ScramUtils.toKafkaScramArguments(clusterConfig.getSaslMechanism(), clusterConfig.getUsers())
+                : List.of();
         try {
             tempDirectory = Files.createTempDirectory("kafka");
             tempDirectory.toFile().deleteOnExit();
@@ -103,7 +108,7 @@ public class InVMKafkaCluster implements KafkaCluster, KafkaListenerSource, Admi
         boolean kraftMode = clusterConfig.isKraftMode();
         if (kraftMode) {
             var clusterId = c.kraftClusterId();
-            KraftLogDirUtil.prepareLogDirsForKraft(clusterId, config);
+            KraftLogDirUtil.prepareLogDirsForKraft(clusterId, config, scramArguments);
             return instantiateKraftServer(config, threadNamePrefix);
         }
         else {
@@ -170,7 +175,9 @@ public class InVMKafkaCluster implements KafkaCluster, KafkaListenerSource, Admi
                 clusterConfig.getAnonConnectConfigForCluster(buildBrokersListFor(Listener.ANON)), 120,
                 TimeUnit.SECONDS,
                 clusterConfig.getBrokersNum());
-        ScramInitialiser.initialiseScramUsers(this, clusterConfig);
+        if (scramArguments.isEmpty()) {
+            ScramInitialiser.initialiseScramUsers(this, clusterConfig);
+        }
     }
 
     private String buildBrokersListFor(Listener listener) {

--- a/impl/src/main/java/io/kroxylicious/testing/kafka/invm/KraftLogDirUtil.java
+++ b/impl/src/main/java/io/kroxylicious/testing/kafka/invm/KraftLogDirUtil.java
@@ -9,6 +9,7 @@ import java.io.PrintStream;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 import org.apache.kafka.common.metadata.FeatureLevelRecord;
@@ -70,11 +71,15 @@ final class KraftLogDirUtil {
     }
 
     static void prepareLogDirsForKraft(String clusterId, KafkaConfig config) {
+        prepareLogDirsForKraft(clusterId, config, List.of());
+    }
+
+    static void prepareLogDirsForKraft(String clusterId, KafkaConfig config, List<String> scramArguments) {
         var metadataVersion = getMetadataVersion(config);
         var directoriesScala = StorageTool.configToLogDirectories(config);
-        tryWithFallbacks(() -> prepareLogDirsForKraftKafka41Plus(clusterId, config, directoriesScala, metadataVersion),
-                () -> prepareLogDirsForKraftKafka39Plus(clusterId, config, directoriesScala, metadataVersion),
-                () -> prepareLogDirsForKraftPreKafka39(clusterId, config, directoriesScala, metadataVersion));
+        tryWithFallbacks(() -> prepareLogDirsForKraftKafka41Plus(clusterId, config, directoriesScala, metadataVersion, scramArguments),
+                () -> prepareLogDirsForKraftKafka39Plus(clusterId, config, directoriesScala, metadataVersion, scramArguments),
+                () -> prepareLogDirsForKraftPreKafka39(clusterId, config, directoriesScala, metadataVersion, scramArguments));
     }
 
     private static MetadataVersion getMetadataVersion(KafkaConfig config) {
@@ -90,7 +95,7 @@ final class KraftLogDirUtil {
     }
 
     private static void prepareLogDirsForKraftKafka41Plus(String clusterId, KafkaConfig config, Seq<String> directoriesScala,
-                                                          MetadataVersion metadataVersion)
+                                                          MetadataVersion metadataVersion, List<String> scramArguments)
             throws Exception {
         var controllerListenerName = config.controllerListenerNames().stream().findFirst().orElseThrow();
         var directories = CollectionConverters.asJava(directoriesScala);
@@ -103,11 +108,14 @@ final class KraftLogDirUtil {
         formatter.setIgnoreFormatted(IGNORE_FORMATTED);
         formatter.setPrintStream(LOGGING_PRINT_STREAM);
         formatter.setReleaseVersion(metadataVersion);
+        if (!scramArguments.isEmpty()) {
+            formatter.setScramArguments(scramArguments);
+        }
         formatter.run();
     }
 
     private static void prepareLogDirsForKraftKafka39Plus(String clusterId, KafkaConfig config, Seq<String> directoriesScala,
-                                                          MetadataVersion metadataVersion)
+                                                          MetadataVersion metadataVersion, List<String> scramArguments)
             throws ClassNotFoundException, InstantiationException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
         // Try Formatter class (introduced Kafka 3.9)
         scala.collection.Seq<String> controllerListenerNameSeq = (scala.collection.Seq<String>) KafkaConfig.class.getMethod("controllerListenerNames")
@@ -125,18 +133,22 @@ final class KraftLogDirUtil {
         formatterClazz.getMethod("setIgnoreFormatted", boolean.class).invoke(formatter, IGNORE_FORMATTED);
         formatterClazz.getMethod("setPrintStream", PrintStream.class).invoke(formatter, LOGGING_PRINT_STREAM);
         formatterClazz.getMethod("setReleaseVersion", MetadataVersion.class).invoke(formatter, metadataVersion);
+        if (!scramArguments.isEmpty()) {
+            formatterClazz.getMethod("setScramArguments", List.class).invoke(formatter, scramArguments);
+        }
 
         formatterClazz.getMethod("run").invoke(formatter);
     }
 
-    private static void prepareLogDirsForKraftPreKafka39(String clusterId, KafkaConfig config, Seq<String> directories, MetadataVersion metadataVersion) {
+    private static void prepareLogDirsForKraftPreKafka39(String clusterId, KafkaConfig config, Seq<String> directories, MetadataVersion metadataVersion,
+                                                         List<String> scramArguments) {
         try {
             // Default the metadata version from the IBP version specified in config in the same way as kafka.tools.StorageTool.
 
             // in kafka 3.7.0 the MetadataProperties class moved package, we use reflection to enable the extension to work with
             // the old and new class.
             var metaProperties = buildMetadataPropertiesReflectively(clusterId, config);
-            var bootstrapMetadata = buildBootstrapMetadata(metadataVersion);
+            var bootstrapMetadata = buildBootstrapMetadata(metadataVersion, scramArguments);
 
             formatReflectively(metaProperties, directories, bootstrapMetadata, metadataVersion);
         }
@@ -164,9 +176,12 @@ final class KraftLogDirUtil {
         }
     }
 
-    private static BootstrapMetadata buildBootstrapMetadata(MetadataVersion metadataVersion) {
+    private static BootstrapMetadata buildBootstrapMetadata(MetadataVersion metadataVersion, List<String> scramArguments) {
         var metadataRecords = new ArrayList<ApiMessageAndVersion>();
         metadataRecords.add(metadataVersionMessage(metadataVersion));
+        ScramUtils.getUserScramCredentialRecords(scramArguments).stream()
+                .map(KraftLogDirUtil::wrap)
+                .forEach(metadataRecords::add);
         return BootstrapMetadata.fromRecords(metadataRecords, KraftLogDirUtil.class.getName());
     }
 

--- a/impl/src/test/java/io/kroxylicious/testing/kafka/invm/KraftLogDirUtilTest.java
+++ b/impl/src/test/java/io/kroxylicious/testing/kafka/invm/KraftLogDirUtilTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Kroxylicious Authors.
+ *
+ * Licensed under the Apache Software License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package io.kroxylicious.testing.kafka.invm;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import org.apache.kafka.common.metadata.UserScramCredentialRecord;
+import org.apache.kafka.metadata.bootstrap.BootstrapDirectory;
+import org.apache.kafka.metadata.bootstrap.BootstrapMetadata;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import kafka.server.KafkaConfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class KraftLogDirUtilTest {
+
+    private Path logDir;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        logDir = Files.createTempDirectory("kraft-test");
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (logDir != null && Files.exists(logDir)) {
+            try (Stream<Path> walk = Files.walk(logDir)) {
+                walk.sorted(Comparator.reverseOrder()).map(Path::toFile).forEach(File::delete);
+            }
+        }
+    }
+
+    @Test
+    void formatsLogDirectoryWithoutScramArguments() {
+        var config = createMinimalKraftConfig();
+        var clusterId = UUID.randomUUID().toString();
+
+        KraftLogDirUtil.prepareLogDirsForKraft(clusterId, config);
+
+        assertThat(logDir.resolve("meta.properties")).exists();
+    }
+
+    @Test
+    void formatsLogDirectoryWithScramArguments() throws Exception {
+        var config = createMinimalKraftConfig();
+        var clusterId = UUID.randomUUID().toString();
+        var scramArguments = List.of("SCRAM-SHA-256=[name=alice,password=alice-secret]");
+
+        KraftLogDirUtil.prepareLogDirsForKraft(clusterId, config, scramArguments);
+
+        assertThat(logDir.resolve("meta.properties")).exists();
+        BootstrapMetadata metadata = new BootstrapDirectory(logDir.toString()).read();
+        assertThat(metadata.records())
+                .extracting(r -> r.message())
+                .hasAtLeastOneElementOfType(UserScramCredentialRecord.class);
+    }
+
+    @Test
+    void formatsLogDirectoryWithMultipleScramUsers() throws Exception {
+        var config = createMinimalKraftConfig();
+        var clusterId = UUID.randomUUID().toString();
+        var scramArguments = List.of(
+                "SCRAM-SHA-512=[name=alice,password=alice-secret]",
+                "SCRAM-SHA-512=[name=bob,password=bob-secret]");
+
+        KraftLogDirUtil.prepareLogDirsForKraft(clusterId, config, scramArguments);
+
+        BootstrapMetadata metadata = new BootstrapDirectory(logDir.toString()).read();
+        var scramRecords = metadata.records().stream()
+                .map(r -> r.message())
+                .filter(UserScramCredentialRecord.class::isInstance)
+                .map(UserScramCredentialRecord.class::cast)
+                .toList();
+        assertThat(scramRecords)
+                .extracting(UserScramCredentialRecord::name)
+                .containsExactlyInAnyOrder("alice", "bob");
+    }
+
+    @Test
+    void emptyScramArgumentsProducesNoScramRecords() throws Exception {
+        var config = createMinimalKraftConfig();
+        var clusterId = UUID.randomUUID().toString();
+
+        KraftLogDirUtil.prepareLogDirsForKraft(clusterId, config, List.of());
+
+        BootstrapMetadata metadata = new BootstrapDirectory(logDir.toString()).read();
+        assertThat(metadata.records())
+                .extracting(r -> r.message())
+                .noneMatch(UserScramCredentialRecord.class::isInstance);
+    }
+
+    private KafkaConfig createMinimalKraftConfig() {
+        Properties props = new Properties();
+        props.setProperty("node.id", "0");
+        props.setProperty("process.roles", "broker,controller");
+        props.setProperty("controller.listener.names", "CONTROLLER");
+        props.setProperty("controller.quorum.voters", "0@localhost:9093");
+        props.setProperty("listeners", "CONTROLLER://localhost:9093,INTERNAL://localhost:9092");
+        props.setProperty("listener.security.protocol.map", "CONTROLLER:PLAINTEXT,INTERNAL:PLAINTEXT");
+        props.setProperty("inter.broker.listener.name", "INTERNAL");
+        props.setProperty("advertised.listeners", "INTERNAL://localhost:9092");
+        props.setProperty("log.dir", logDir.toAbsolutePath().toString());
+        return new KafkaConfig(props);
+    }
+}


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

The `ScramInitialiser` created SCRAM credentials via the Kafka `Admin` API after cluster startup, then verified them with `describeUserScramCredentials`. However, that check only confirms the controller has committed the records — the broker's credential cache is populated asynchronously from the metadata log. Under CI load, tests could authenticate in the gap before the broker replayed the records, causing flaky `SaslAuthenticationException` failures in `saslScramAuth`.

Bootstrap SCRAM credentials into the KRaft metadata log at format time using `Formatter.setScramArguments()`, so they are available as soon as the broker starts. Skip the post-startup `ScramInitialiser` call when credentials have been bootstrapped.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>

### Additional Context

Fixes #654

