### PR TITLE
ci(sonar): run scanner under JDK 21

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -60,8 +60,10 @@ jobs:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 #v4.2.0
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: ./.github/actions/common/setup-java
+        with:
+          javaVersion: "21"
 
       - name: Cache SonarCloud packages
         uses: ./.github/actions/common/cache-sonar-packages


### PR DESCRIPTION
### Type of change

- Build fix

### Description

SonarQube Cloud no longer supports running analysis with Java 17. Use JDK 21 to run the scanner while keeping the project compilation target at Java 17.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>

### Additional Context

Builds are currently failing because of they no longer support Java 17, see e.g. https://github.com/kroxylicious/kroxylicious-junit5-extension/actions/runs/29867581442/job/88759537626#step:8:874

